### PR TITLE
Process fulfilment

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -5,11 +5,18 @@ import logging
 import requests
 from structlog import wrap_logger
 
+from acceptance_tests.utilities.database_helper import open_write_cursor
 from acceptance_tests.utilities.rabbit_helper import purge_queues
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 logger = wrap_logger(logging.getLogger(__name__))
+
+
+def purge_fulfilment_triggers():
+    with open_write_cursor() as cur:
+        delete_trigger_query = """DELETE FROM casev3.fulfilment_next_trigger"""
+        cur.execute(delete_trigger_query)
 
 
 def before_all(_):
@@ -20,6 +27,7 @@ def before_scenario(context, _):
     context.test_start_local_datetime = datetime.now()
     context.test_start_utc = datetime.utcnow()
     purge_queues()
+    purge_fulfilment_triggers()
 
 
 def after_all(_context):

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -1,0 +1,10 @@
+
+Feature: requesting fulfilments for a case
+
+  Scenario: A print fulfilment is requested for a case
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And a fulfilment template has been created with template "["ADDRESS_LINE1","POSTCODE","__uac__"]" and print supplier "SUPPLIER_A"
+    And a fulfilment has been requested
+    When fulfilments trigger
+    Then uac_updated msgs are emitted with active set to true
+    And a print file is created with correct rows

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -1,0 +1,55 @@
+import json
+import uuid
+from datetime import datetime
+
+from behave import step
+
+from acceptance_tests.utilities.database_helper import open_write_cursor
+from acceptance_tests.utilities.rabbit_context import RabbitContext
+from config import Config
+
+
+@step('a fulfilment has been requested')
+def request_fulfilment_step(context):
+    message = json.dumps(
+        {
+            "event": {
+                "type": "FULFILMENT",
+                "source": "RH",
+                "channel": "RH",
+                "dateTime": "2021-06-09T13:49:19.716761Z",
+                "transactionId": "92df974c-f03e-4519-8d55-05e9c0ecea43"
+            },
+            "payload": {
+                "fulfilment": {
+                    "caseId": context.loaded_case_ids[0],
+                    "fulfilmentCode": context.unique_template_code
+                }
+            }
+        })
+
+    with RabbitContext(exchange='') as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_FULFILMENT_QUEUE)
+
+
+@step('a fulfilment template has been created with template "{template}" and print supplier "{supplier}"')
+def fulfilment_template_step(context, template, supplier):
+    with open_write_cursor() as cur:
+        add_template_query = """INSERT INTO casev3.fulfilment_template
+                                (fulfilment_code, template, print_supplier) VALUES(%s,%s,%s)"""
+        context.unique_template_code = 'AT_TEMPLATE_' + str(uuid.uuid4())
+        context.template = template
+        context.pack_code = context.unique_template_code
+        template_vars = (context.unique_template_code, template, supplier)
+        cur.execute(add_template_query, vars=template_vars)
+
+
+@step('fulfilments trigger')
+def fulfilments_trigger_step(context):
+    with open_write_cursor() as cur:
+        add_trigger_query = """INSERT INTO casev3.fulfilment_next_trigger (id, trigger_date_time) VALUES(%s,%s)"""
+        trigger_vars = (str(uuid.uuid4()), datetime.utcnow())
+        cur.execute(add_trigger_query, vars=trigger_vars)

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config:
     RABBITMQ_RESPONSE_QUEUE = os.getenv('RABBITMQ_RESPONSE_QUEUE', 'events.caseProcessor.response')
     RABBITMQ_REFUSAL_QUEUE = os.getenv('RABBITMQ_REFUSAL_QUEUE', 'events.caseProcessor.refusal')
     RABBITMQ_INVALID_ADDRESS_QUEUE = os.getenv('RABBITMQ_INVALID_ADDRESS_QUEUE', 'events.caseProcessor.invalidAddress')
+    RABBITMQ_FULFILMENT_QUEUE = os.getenv('RABBITMQ_FULFILMENT_QUEUE', 'events.caseProcessor.fulfilment')
     RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY = os.getenv('RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY',
                                                      'events.caseProcessor.surveyLaunched')
 


### PR DESCRIPTION
# Motivation and Context
We have a theoretical requirement to be able to do print fulfilments, for example for a replacement UAC if a respondent loses theirs.

# What has changed
Added print fulfilment capability.

# How to test?
You need to define a template for each fulfilment code, and configure a print supplier. You can do that by inserting a row into the database like this: `insert into casev3.fulfilment_template values ('TEST_FULFILMENT_CODE', '"__caseref__","__uac__"', 'SUPPLIER_A');`

Then, you need to send in some requests for fulfilments. The messages look like this:
```json
{
  "event": {
    "type": "FULFILMENT",
    "source": "RH",
    "channel": "RH",
    "dateTime": "2021-06-09T13:49:19.716761Z",
    "transactionId": "92df974c-f03e-4519-8d55-05e9c0ecea43"
  },
  "payload": {
    "fulfilment": {
      "caseId": "3b768940-6ef2-460e-bb75-e51d3a65ada4",
      "fulfilmentCode": "TEST_FULFILMENT_CODE"
    }
  }
}
```

Then, go right ahead and set up a fulfilment trigger time, using this SQL: `insert into casev3.fulfilment_next_trigger values ('b1d826fa-6afc-4270-9f0c-302cb05d4d96', '2021-06-28T10:40:00.000Z');`

Then, majick happenz.

# Links
Trello: https://trello.com/c/qIdPbsJG