### PR TITLE
Deactivate UAC

### DIFF
--- a/acceptance_tests/features/deactivate_uac.feature
+++ b/acceptance_tests/features/deactivate_uac.feature
@@ -1,0 +1,16 @@
+
+Feature: deactivate UACs for a case
+
+  Scenario: A case is loaded, action rule is triggered and UAC is deactivated for that case
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And UAC_UPDATED messages are emitted with active set to true
+    When a deactivate uac action rule has been created
+    Then UAC_UPDATED messages are emitted with active set to false
+
+  Scenario: A deactivate UAC event is received for a QID and the UAC is deactivated
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And UAC_UPDATED messages are emitted with active set to true
+    When a deactivate uac message is put on the queue
+    Then UAC_UPDATED messages are emitted with active set to false

--- a/acceptance_tests/features/deactivate_uac.feature
+++ b/acceptance_tests/features/deactivate_uac.feature
@@ -3,14 +3,14 @@ Feature: deactivate UACs for a case
 
   Scenario: A case is loaded, action rule is triggered and UAC is deactivated for that case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a deactivate uac action rule has been created
     Then UAC_UPDATED messages are emitted with active set to false
 
   Scenario: A deactivate UAC event is received for a QID and the UAC is deactivated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a deactivate uac message is put on the queue
     Then UAC_UPDATED messages are emitted with active set to false

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -1,8 +1,10 @@
 import logging
 import time
 from datetime import datetime
+from distutils.util import strtobool
 
 import requests
+from behave import register_type
 from structlog import wrap_logger
 
 from acceptance_tests.utilities.database_helper import open_write_cursor
@@ -11,6 +13,8 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 logger = wrap_logger(logging.getLogger(__name__))
+
+register_type(Boolean=lambda text: strtobool(text))
 
 
 def purge_fulfilment_triggers():

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -14,7 +14,7 @@ from config import Config
 
 logger = wrap_logger(logging.getLogger(__name__))
 
-register_type(Boolean=lambda text: strtobool(text))
+register_type(boolean=lambda text: strtobool(text))
 
 
 def purge_fulfilment_triggers():

--- a/acceptance_tests/features/invalid_address.feature
+++ b/acceptance_tests/features/invalid_address.feature
@@ -2,7 +2,7 @@ Feature: An address can be invalidated with an event
 
   Scenario: A case is loaded and can be set to address invalid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print wave of contact has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
     And UAC_UPDATED messages are emitted with active set to true
     When an ADDRESS_NOT_VALID event is received
     Then a CASE_UPDATED message is emitted where "invalidAddress" is "True"

--- a/acceptance_tests/features/invalid_address.feature
+++ b/acceptance_tests/features/invalid_address.feature
@@ -2,7 +2,7 @@ Feature: An address can be invalidated with an event
 
   Scenario: A case is loaded and can be set to address invalid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When an ADDRESS_NOT_VALID event is received
     Then a CASE_UPDATED message is emitted where "invalidAddress" is "True"

--- a/acceptance_tests/features/printfile.feature
+++ b/acceptance_tests/features/printfile.feature
@@ -2,7 +2,7 @@ Feature: Print files can be created and sent with correct data
 
   Scenario Outline: A case is loaded, action rule triggered and print file created with differing templates with UACs
     Given sample file "<sample file>" is loaded successfully
-    When a print action rule has been created with template "<template>" and classifiers "1=1"
+    When a print action rule has been created with template "<template>"
     Then UAC_UPDATED messages are emitted with active set to true
     And a print file is created with correct rows
 
@@ -13,7 +13,7 @@ Feature: Print files can be created and sent with correct data
 
   Scenario Outline: A case is loaded, action rule triggered and print file created with differing templates no UACs
     Given sample file "<sample file>" is loaded successfully
-    When a print action rule has been created with template "<template>" and classifiers "1=1"
+    When a print action rule has been created with template "<template>"
     And a print file is created with correct rows
 
     Examples:

--- a/acceptance_tests/features/printfile.feature
+++ b/acceptance_tests/features/printfile.feature
@@ -1,8 +1,8 @@
 Feature: Print files can be created and sent with correct data
 
-  Scenario Outline: A case is loaded, wave of contact triggered and print file created with differing templates with UACs
+  Scenario Outline: A case is loaded, action rule triggered and print file created with differing templates with UACs
     Given sample file "<sample file>" is loaded successfully
-    When a print wave of contact has been created with template "<template>" and classifiers "1=1"
+    When a print action rule has been created with template "<template>" and classifiers "1=1"
     Then UAC_UPDATED messages are emitted with active set to true
     And a print file is created with correct rows
 
@@ -11,9 +11,9 @@ Feature: Print files can be created and sent with correct data
       | social_sample_3_lines_fields.csv | ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE","__uac__"]       |
       | business_sample_6_lines.csv      | ["BUSINESS_NAME","TOWN_NAME","__uac__","__qid__","INDUSTRY"] |
 
-  Scenario Outline: A case is loaded, wave of contact triggered and print file created with differing templates no UACs
+  Scenario Outline: A case is loaded, action rule triggered and print file created with differing templates no UACs
     Given sample file "<sample file>" is loaded successfully
-    When a print wave of contact has been created with template "<template>" and classifiers "1=1"
+    When a print action rule has been created with template "<template>" and classifiers "1=1"
     And a print file is created with correct rows
 
     Examples:
@@ -21,9 +21,9 @@ Feature: Print files can be created and sent with correct data
       | social_sample_3_lines_fields.csv | ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE"] |
       | business_sample_6_lines.csv      | ["BUSINESS_NAME","TOWN_NAME","INDUSTRY"]     |
 
-  Scenario Outline: A case is loaded wave of contact triggered and print file created with differing classifiers
+  Scenario Outline: A case is loaded action rule triggered and print file created with differing classifiers
     Given sample file "<sample file>" is loaded successfully
-    When a print wave of contact has been created with template "["__uac__"]" and classifiers "<classifiers>"
+    When a print action rule has been created with template "["__uac__"]" and classifiers "<classifiers>"
     Then <expected row count> UAC_UPDATED messages are emitted with active set to true
     Then a print file is created with correct rows
 

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -2,7 +2,7 @@ Feature: A case can be receipted with an event
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic
     Then a UAC_UPDATED message is emitted with active set to false

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -2,7 +2,7 @@ Feature: A case can be receipted with an event
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print wave of contact has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
     And UAC_UPDATED messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic
     Then a UAC_UPDATED message is emitted with active set to false

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -2,7 +2,7 @@ Feature: A case can be refused with an event
 
   Scenario: A case is loaded and can be refused
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a REFUSAL_RECEIVED event is received
     Then a CASE_UPDATED message is emitted where "refusalReceived" is "EXTRAORDINARY_REFUSAL"

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -2,7 +2,7 @@ Feature: A case can be refused with an event
 
   Scenario: A case is loaded and can be refused
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print wave of contact has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
     And UAC_UPDATED messages are emitted with active set to true
     When a REFUSAL_RECEIVED event is received
     Then a CASE_UPDATED message is emitted where "refusalReceived" is "EXTRAORDINARY_REFUSAL"

--- a/acceptance_tests/features/respondent_authenticated.feature
+++ b/acceptance_tests/features/respondent_authenticated.feature
@@ -2,7 +2,7 @@ Feature: Handle respondent authenticated events
 
   Scenario: A case is loaded and a respondent can authenticate against it
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a RESPONDENT_AUTHENTICATED event is received
     Then the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,RESPONDENT_AUTHENTICATED]

--- a/acceptance_tests/features/respondent_authenticated.feature
+++ b/acceptance_tests/features/respondent_authenticated.feature
@@ -2,7 +2,7 @@ Feature: Handle respondent authenticated events
 
   Scenario: A case is loaded and a respondent can authenticate against it
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print wave of contact has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
     And UAC_UPDATED messages are emitted with active set to true
     When a RESPONDENT_AUTHENTICATED event is received
     Then the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,RESPONDENT_AUTHENTICATED]

--- a/acceptance_tests/features/steps/action_rule.py
+++ b/acceptance_tests/features/steps/action_rule.py
@@ -1,0 +1,15 @@
+from behave import step
+
+from acceptance_tests.utilities.action_rule_helper import create_print_action_rule, \
+    setup_deactivate_uac_action_rule
+
+
+@step('a print action rule has been created with template "{template}" and classifiers "{classifiers}"')
+def create_print_action_rule_with_template_and_classifiers(context, template, classifiers):
+    context.template = template
+    context.pack_code = create_print_action_rule(context.collex_id, classifiers, template)
+
+
+@step('a deactivate uac action rule has been created')
+def create_deactivate_uac_action_rule(context):
+    setup_deactivate_uac_action_rule(context.collex_id)

--- a/acceptance_tests/features/steps/action_rule.py
+++ b/acceptance_tests/features/steps/action_rule.py
@@ -7,7 +7,13 @@ from acceptance_tests.utilities.action_rule_helper import create_print_action_ru
 @step('a print action rule has been created with template "{template}" and classifiers "{classifiers}"')
 def create_print_action_rule_with_template_and_classifiers(context, template, classifiers):
     context.template = template
-    context.pack_code = create_print_action_rule(context.collex_id, classifiers, template)
+    context.pack_code = create_print_action_rule(context.collex_id, template, classifiers)
+
+
+@step('a print action rule has been created with template "{template}"')
+def create_print_action_rule_with_template(context, template):
+    context.template = template
+    context.pack_code = create_print_action_rule(context.collex_id, template)
 
 
 @step('a deactivate uac action rule has been created')

--- a/acceptance_tests/features/steps/deactivate_uac.py
+++ b/acceptance_tests/features/steps/deactivate_uac.py
@@ -1,0 +1,28 @@
+import json
+
+from behave import step
+
+from acceptance_tests.utilities.rabbit_helper import publish_json_message
+from config import Config
+
+
+@step("a deactivate uac message is put on the queue")
+def step_impl(context):
+    message = json.dumps(
+        {
+            "event": {
+                "type": "DEACTIVATE_UAC",
+                "source": "CC",
+                "channel": "CC",
+                "dateTime": "2021-06-09T13:49:19.716761Z",
+                "transactionId": "92df974c-f03e-4519-8d55-05e9c0ecea43"
+            },
+            "payload": {
+                "deactivateUac": {
+                    "qid": context.emitted_uacs[0]['questionnaireId'],
+                }
+            }
+        })
+
+    publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE,
+                         routing_key=Config.RABBITMQ_DEACTIVATE_UAC_QUEUE)

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-
 from behave import step
 
 from acceptance_tests.utilities.event_helper import get_emitted_case_update, get_emitted_uac_update, \

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -23,7 +23,7 @@ def case_updated_msg_sent_with_values(context, case_field, expected_field_value)
                             'The updated case field must match the expected value')
 
 
-@step("UAC_UPDATED messages are emitted with active set to {active:Boolean}")
+@step("UAC_UPDATED messages are emitted with active set to {active:boolean}")
 def check_uac_updated_msgs_emitted_with_qid_active(context, active):
     context.emitted_uacs = get_uac_updated_events(len(context.emitted_cases))
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
@@ -31,7 +31,7 @@ def check_uac_updated_msgs_emitted_with_qid_active(context, active):
     _check_new_uacs_are_as_expected(context.emitted_uacs, active)
 
 
-@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active:Boolean}")
+@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active:boolean}")
 def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active):
     context.emitted_uacs = get_uac_updated_events(expected_count)
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -1,3 +1,5 @@
+from distutils.util import strtobool
+
 from behave import step
 
 from acceptance_tests.utilities.event_helper import get_emitted_case_update, get_emitted_uac_update, \
@@ -23,25 +25,19 @@ def case_updated_msg_sent_with_values(context, case_field, expected_field_value)
                             'The updated case field must match the expected value')
 
 
-@step("UAC_UPDATED messages are emitted with active set to {active_str}")
-def check_uac_updated_msgs_emitted_with_qid_active(context, active_str):
+@step("UAC_UPDATED messages are emitted with active set to {active}")
+def check_uac_updated_msgs_emitted_with_qid_active(context, active):
     context.emitted_uacs = get_uac_updated_events(len(context.emitted_cases))
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
 
-    active = False
-    if active_str == 'true':
-        active = True
-    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, active)
+    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, strtobool(active))
 
 
-@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active_str}")
-def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active_str):
+@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active}")
+def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active):
     context.emitted_uacs = get_uac_updated_events(expected_count)
 
-    active = False
-    if active_str == 'true':
-        active = True
-    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, active)
+    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, strtobool(active))
 
     included_case_ids = {event['caseId'] for event in context.emitted_uacs}
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -23,17 +23,25 @@ def case_updated_msg_sent_with_values(context, case_field, expected_field_value)
                             'The updated case field must match the expected value')
 
 
-@step("UAC_UPDATED messages are emitted with active set to true")
-def check_uac_updated_msgs_emitted_with_qid_active(context):
+@step("UAC_UPDATED messages are emitted with active set to {active_str}")
+def check_uac_updated_msgs_emitted_with_qid_active(context, active_str):
     context.emitted_uacs = get_uac_updated_events(len(context.emitted_cases))
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
-    _check_uac_updated_events(context.emitted_uacs, context.collex_id)
+
+    active = False
+    if active_str == 'true':
+        active = True
+    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, active)
 
 
-@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to true")
-def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count):
+@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active_str}")
+def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active_str):
     context.emitted_uacs = get_uac_updated_events(expected_count)
-    _check_uac_updated_events(context.emitted_uacs, context.collex_id)
+
+    active = False
+    if active_str == 'true':
+        active = True
+    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, active)
 
     included_case_ids = {event['caseId'] for event in context.emitted_uacs}
 
@@ -41,8 +49,9 @@ def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count):
     context.emitted_cases = [case for case in context.emitted_cases if case['caseId'] in included_case_ids]
 
 
-def _check_uac_updated_events(emitted_uacs, collex_id):
+def _check_new_uacs_are_as_expected(emitted_uacs, collex_id, active):
     for uac in emitted_uacs:
+        test_helper.assertEqual(uac['active'], active)
         test_helper.assertEqual(uac['collectionExerciseId'], str(collex_id),
                                 f'UAC updates should all be for the current collection exericse,'
                                 f' QID: {uac["questionnaireId"]}')

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -25,19 +25,19 @@ def case_updated_msg_sent_with_values(context, case_field, expected_field_value)
                             'The updated case field must match the expected value')
 
 
-@step("UAC_UPDATED messages are emitted with active set to {active}")
+@step("UAC_UPDATED messages are emitted with active set to {active:Boolean}")
 def check_uac_updated_msgs_emitted_with_qid_active(context, active):
     context.emitted_uacs = get_uac_updated_events(len(context.emitted_cases))
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
 
-    _check_new_uacs_are_as_expected(context.emitted_uacs, strtobool(active))
+    _check_new_uacs_are_as_expected(context.emitted_uacs, active)
 
 
-@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active}")
+@step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active:Boolean}")
 def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active):
     context.emitted_uacs = get_uac_updated_events(expected_count)
 
-    _check_new_uacs_are_as_expected(context.emitted_uacs, strtobool(active))
+    _check_new_uacs_are_as_expected(context.emitted_uacs, active)
 
     included_case_ids = {event['caseId'] for event in context.emitted_uacs}
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -30,14 +30,14 @@ def check_uac_updated_msgs_emitted_with_qid_active(context, active):
     context.emitted_uacs = get_uac_updated_events(len(context.emitted_cases))
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
 
-    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, strtobool(active))
+    _check_new_uacs_are_as_expected(context.emitted_uacs, strtobool(active))
 
 
 @step("{expected_count:d} UAC_UPDATED messages are emitted with active set to {active}")
 def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, active):
     context.emitted_uacs = get_uac_updated_events(expected_count)
 
-    _check_new_uacs_are_as_expected(context.emitted_uacs, context.collex_id, strtobool(active))
+    _check_new_uacs_are_as_expected(context.emitted_uacs, strtobool(active))
 
     included_case_ids = {event['caseId'] for event in context.emitted_uacs}
 
@@ -45,16 +45,9 @@ def check_expected_number_of_uac_updated_msgs_emitted(context, expected_count, a
     context.emitted_cases = [case for case in context.emitted_cases if case['caseId'] in included_case_ids]
 
 
-def _check_new_uacs_are_as_expected(emitted_uacs, collex_id, active):
+def _check_new_uacs_are_as_expected(emitted_uacs, active):
     for uac in emitted_uacs:
         test_helper.assertEqual(uac['active'], active)
-        test_helper.assertEqual(uac['collectionExerciseId'], str(collex_id),
-                                f'UAC updates should all be for the current collection exericse,'
-                                f' QID: {uac["questionnaireId"]}')
-        test_helper.assertTrue(uac['active'],
-                               f'Newly created UAC QID pairs should be active, QID: {uac["questionnaireId"]}')
-        test_helper.assertIsNotNone(uac['caseId'], f'Newly created UAC QID pairs should always be linked to a case, '
-                                                   f'QID without link: {uac["questionnaireId"]}')
 
 
 def _check_uacs_updated_match_cases(uac_updated_events, cases):

--- a/acceptance_tests/features/steps/wave_of_contact.py
+++ b/acceptance_tests/features/steps/wave_of_contact.py
@@ -1,9 +1,0 @@
-from behave import step
-
-from acceptance_tests.utilities.wave_of_contact_helper import create_print_wave_of_contact
-
-
-@step('a print wave of contact has been created with template "{template}" and classifiers "{classifiers}"')
-def create_print_wave_of_contact_with_template_and_classifers(context, template, classifiers):
-    context.template = template
-    context.pack_code = create_print_wave_of_contact(context.collex_id, classifiers, template)

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -2,7 +2,7 @@ Feature: Handle survey launch events
 
   Scenario: Survey launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print wave of contact has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
     And UAC_UPDATED messages are emitted with active set to true
     When a SURVEY_LAUNCHED event is received
     Then a CASE_UPDATED message is emitted where "surveyLaunched" is "True"

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -2,7 +2,7 @@ Feature: Handle survey launch events
 
   Scenario: Survey launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And a print action rule has been created with template "["__uac__"]" and classifiers "1=1"
+    And a print action rule has been created with template "["__uac__"]"
     And UAC_UPDATED messages are emitted with active set to true
     When a SURVEY_LAUNCHED event is received
     Then a CASE_UPDATED message is emitted where "surveyLaunched" is "True"

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -9,7 +9,7 @@ import requests
 from config import Config
 
 
-def create_print_action_rule(collex_id, classifiers, template):
+def create_print_action_rule(collex_id, template, classifiers=None):
     # whilst action rules are created to get a UAC for example to receipt, a printfile will still be created after
     # that test has finished, this interferes with other tests as the printfile timestamps is often after the start
     # of the next test.
@@ -24,7 +24,7 @@ def create_print_action_rule(collex_id, classifiers, template):
         'packCode': pack_code,
         'triggerDateTime': f'{datetime.utcnow().isoformat()}Z',
         'hasTriggered': False,
-        'classifiers': classifiers,
+        'classifiers': classifiers if classifiers else '',
         'template': json.loads(template),
         'printSupplier': 'SUPPLIER_A',
         'collectionExercise': 'collectionExercises/' + collex_id

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -9,15 +9,15 @@ import requests
 from config import Config
 
 
-def create_print_wave_of_contact(collex_id, classifiers, template):
-    # whilst WOCs are created to get a UAC for example to receipt, a printfile will still be created after
+def create_print_action_rule(collex_id, classifiers, template):
+    # whilst action rules are created to get a UAC for example to receipt, a printfile will still be created after
     # that test has finished, this interferes with other tests as the printfile timestamps is often after the start
     # of the next test.
     # By using a unique random pack_code we have better filter options
     # We can change/remove this if we get UACS differently or a better solution is found
     pack_code = 'pack_code_' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
 
-    url = f'{Config.SUPPORT_TOOL}/waveOfContacts'
+    url = f'{Config.SUPPORT_TOOL}/actionRules'
     body = {
         'id': str(uuid.uuid4()),
         'type': 'PRINT',
@@ -33,3 +33,21 @@ def create_print_wave_of_contact(collex_id, classifiers, template):
     response = requests.post(url, json=body)
     response.raise_for_status()
     return pack_code
+
+
+def setup_deactivate_uac_action_rule(collex_id):
+    url = f'{Config.SUPPORT_TOOL}/actionRules'
+    body = {
+        'id': str(uuid.uuid4()),
+        'type': 'DEACTIVATE_UAC',
+        'packCode': None,
+        'triggerDateTime': f'{datetime.utcnow().isoformat()}Z',
+        'hasTriggered': False,
+        'classifiers': '',
+        'template': None,
+        'printSupplier': None,
+        'collectionExercise': 'collectionExercises/' + collex_id
+    }
+
+    response = requests.post(url, json=body)
+    response.raise_for_status()

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config:
     RABBITMQ_FULFILMENT_QUEUE = os.getenv('RABBITMQ_FULFILMENT_QUEUE', 'events.caseProcessor.fulfilment')
     RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY = os.getenv('RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY',
                                                      'events.caseProcessor.surveyLaunched')
+    RABBITMQ_DEACTIVATE_UAC_QUEUE = os.getenv('RABBITMQ_DEACTIVATE_UAC_QUEUE', 'events.caseProcessor.deactivateUac')
 
     RABBITMQ_RH_OUTBOUND_UAC_QUEUE = os.getenv('RABBITMQ_RH_OUTBOUND_UAC_QUEUE', 'events.rh.uacUpdate')
     RABBITMQ_RH_OUTBOUND_CASE_QUEUE = os.getenv('RABBITMQ_RH_OUTBOUND_CASE_QUEUE', 'events.rh.caseUpdate')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
We need to be able to deactivate UACs on a certain date, when we no longer want to allow respondents to launch EQ.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Add tests for deactivate UAC from action rule trigger and for message end point
Change "wave of contact" to be "action rule" instead

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the tests

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/MvZRwX7P/2323-generic-survey-uac-deactivation-rule-13