### PR TITLE
Consistent routing keys

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -7,7 +7,7 @@ import requests
 from behave import register_type
 from structlog import wrap_logger
 
-from acceptance_tests.utilities.database_helper import open_write_cursor
+from acceptance_tests.utilities.database_helper import open_cursor
 from acceptance_tests.utilities.rabbit_helper import purge_queues
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -18,7 +18,7 @@ register_type(boolean=lambda text: strtobool(text))
 
 
 def purge_fulfilment_triggers():
-    with open_write_cursor() as cur:
+    with open_cursor() as cur:
         delete_trigger_query = """DELETE FROM casev3.fulfilment_next_trigger"""
         cur.execute(delete_trigger_query)
 

--- a/acceptance_tests/features/sensitive_data.feature
+++ b/acceptance_tests/features/sensitive_data.feature
@@ -2,6 +2,6 @@ Feature: Sample data in the case is sensitive and must be redacted
 
   Scenario: A case is loaded and sensitive data can be changed
     Given sample file "sensitive_data_sample.csv" with sensitive column PHONE_NUMBER is loaded successfully
-    When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER
-    Then the PHONE_NUMBER in the sensitive data on the case is updated
+    When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER to 07898787878
+    Then the PHONE_NUMBER in the sensitive data on the case has been updated to 07898787878
     And the events logged against the case are [SAMPLE_LOADED,UPDATE_SAMPLE_SENSITIVE]

--- a/acceptance_tests/features/steps/deactivate_uac.py
+++ b/acceptance_tests/features/steps/deactivate_uac.py
@@ -25,4 +25,4 @@ def step_impl(context):
         })
 
     publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE,
-                         routing_key=Config.RABBITMQ_DEACTIVATE_UAC_QUEUE)
+                         routing_key=Config.RABBITMQ_DEACTIVATE_UAC_ROUTING_KEY)

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import requests
 from behave import step
 
-from acceptance_tests.utilities.database_helper import open_write_cursor
+from acceptance_tests.utilities.database_helper import open_cursor
 from acceptance_tests.utilities.rabbit_helper import publish_json_message
 from config import Config
 
@@ -34,7 +34,7 @@ def request_print_fulfilment_step(context):
 
 @step('print fulfilments are triggered to be sent for printing')
 def print_fulfilments_trigger_step(context):
-    with open_write_cursor() as cur:
+    with open_cursor() as cur:
         add_trigger_query = """INSERT INTO casev3.fulfilment_next_trigger (id, trigger_date_time) VALUES(%s,%s)"""
         trigger_vars = (str(uuid.uuid4()), datetime.utcnow())
         cur.execute(add_trigger_query, vars=trigger_vars)

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -28,7 +28,8 @@ def request_print_fulfilment_step(context):
                 }
             }
         })
-    publish_json_message(message, routing_key=Config.RABBITMQ_FULFILMENT_QUEUE)
+    publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE,
+                         routing_key=Config.RABBITMQ_FULFILMENT_ROUTING_KEY)
 
 
 @step('print fulfilments are triggered to be sent for printing')

--- a/acceptance_tests/features/steps/invalid_address.py
+++ b/acceptance_tests/features/steps/invalid_address.py
@@ -27,4 +27,4 @@ def send_invalid_address_msg(context):
         })
 
     publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE,
-                         routing_key=Config.RABBITMQ_INVALID_ADDRESS_QUEUE)
+                         routing_key=Config.RABBITMQ_INVALID_ADDRESS_ROUTING_KEY)

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -27,4 +27,5 @@ def send_refusal_msg(context):
             }
         })
 
-    publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE, routing_key=Config.RABBITMQ_REFUSAL_QUEUE)
+    publish_json_message(message, exchange=Config.RABBITMQ_EVENT_EXCHANGE,
+                         routing_key=Config.RABBITMQ_REFUSAL_ROUTING_KEY)

--- a/acceptance_tests/utilities/database_helper.py
+++ b/acceptance_tests/utilities/database_helper.py
@@ -6,7 +6,7 @@ from config import Config
 
 
 @contextlib.contextmanager
-def open_write_cursor(db_host=Config.DB_HOST_CASE, extra_options=""):
+def open_cursor(db_host=Config.DB_HOST_CASE, extra_options=""):
     conn = psycopg2.connect(f"dbname='{Config.DB_NAME}' user='{Config.DB_USERNAME}' host='{db_host}' "
                             f"password='{Config.DB_PASSWORD}' port='{Config.DB_PORT}'"
                             f"{Config.DB_CASE_CERTIFICATES}{extra_options}")

--- a/config.py
+++ b/config.py
@@ -11,14 +11,14 @@ class Config:
 
     RABBITMQ_EVENT_EXCHANGE = os.getenv('RABBITMQ_EVENT_EXCHANGE', 'events')
 
-    RABBITMQ_REFUSAL_QUEUE = os.getenv('RABBITMQ_REFUSAL_QUEUE', 'events.caseProcessor.refusal')
-    RABBITMQ_INVALID_ADDRESS_QUEUE = os.getenv('RABBITMQ_INVALID_ADDRESS_QUEUE', 'events.caseProcessor.invalidAddress')
-    RABBITMQ_FULFILMENT_QUEUE = os.getenv('RABBITMQ_FULFILMENT_QUEUE', 'events.caseProcessor.fulfilment')
+    RABBITMQ_REFUSAL_ROUTING_KEY = os.getenv('RABBITMQ_REFUSAL_ROUTING_KEY', 'events.refusal')
+    RABBITMQ_INVALID_ADDRESS_ROUTING_KEY = os.getenv('RABBITMQ_INVALID_ADDRESS_ROUTING_KEY', 'events.invalidAddress')
+    RABBITMQ_FULFILMENT_ROUTING_KEY = os.getenv('RABBITMQ_FULFILMENT_ROUTING_KEY', 'events.fulfilment')
     RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY = os.getenv('RABBITMQ_SURVEY_LAUNCHED_ROUTING_KEY',
-                                                     'events.caseProcessor.surveyLaunched')
-    RABBITMQ_DEACTIVATE_UAC_QUEUE = os.getenv('RABBITMQ_DEACTIVATE_UAC_QUEUE', 'events.caseProcessor.deactivateUac')
+                                                     'events.surveyLaunched')
+    RABBITMQ_DEACTIVATE_UAC_ROUTING_KEY = os.getenv('RABBITMQ_DEACTIVATE_UAC_ROUTING_KEY', 'events.deactivateUac')
     RABBITMQ_UPDATE_SAMPLE_SENSITIVE_ROUTING_KEY = os.getenv('RABBITMQ_UPDATE_SAMPLE_SENSITIVE_ROUTING_KEY',
-                                                             'events.caseProcessor.updateSampleSensitive')
+                                                             'events.updateSampleSensitive')
 
     RABBITMQ_RH_OUTBOUND_UAC_QUEUE = os.getenv('RABBITMQ_RH_OUTBOUND_UAC_QUEUE', 'events.rh.uacUpdate')
     RABBITMQ_RH_OUTBOUND_CASE_QUEUE = os.getenv('RABBITMQ_RH_OUTBOUND_CASE_QUEUE', 'events.rh.caseUpdate')


### PR DESCRIPTION
# Motivation and Context
Routing key != queue name. If you want to send directly to a queue, use the default exchange. Otherwise, use the `events` exchange with a meaningful routing key.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Named the routing keys better.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/4CgML4w6