### PR TITLE
Removal of Bad Events

### DIFF
--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -8,4 +8,4 @@ Feature: Fulfilments can be requested for a case
     When print fulfilments are triggered to be sent for printing
     Then UAC_UPDATED messages are emitted with active set to true
     And a print file is created with correct rows
-    And the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,FULFILMENT]
+    And the events logged against the case are [CASE_CREATED,PRINTED_PACK_CODE,FULFILMENT]

--- a/acceptance_tests/features/invalid_address.feature
+++ b/acceptance_tests/features/invalid_address.feature
@@ -4,4 +4,4 @@ Feature: An address can be invalidated with an event
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When an ADDRESS_NOT_VALID event is received
     Then a CASE_UPDATED message is emitted where "invalidAddress" is "True"
-    And the events logged against the case are [SAMPLE_LOADED,ADDRESS_NOT_VALID]
+    And the events logged against the case are [CASE_CREATED,ADDRESS_NOT_VALID]

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -8,4 +8,4 @@ Feature: A case can be receipted with an event
     When a receipt message is published to the pubsub receipting topic
     Then a UAC_UPDATED message is emitted with active set to false
     And a CASE_UPDATED message is emitted where "receiptReceived" is "True"
-    And the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,RESPONSE_RECEIVED]
+    And the events logged against the case are [CASE_CREATED,PRINTED_PACK_CODE,RESPONSE_RECEIVED]

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -4,4 +4,4 @@ Feature: A case can be refused with an event
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When a REFUSAL_RECEIVED event is received
     Then a CASE_UPDATED message is emitted where "refusalReceived" is "EXTRAORDINARY_REFUSAL"
-    And the events logged against the case are [SAMPLE_LOADED,REFUSAL_RECEIVED]
+    And the events logged against the case are [CASE_CREATED,REFUSAL_RECEIVED]

--- a/acceptance_tests/features/respondent_authenticated.feature
+++ b/acceptance_tests/features/respondent_authenticated.feature
@@ -6,4 +6,4 @@ Feature: Handle respondent authenticated events
     And a print action rule has been created
     And UAC_UPDATED messages are emitted with active set to true
     When a RESPONDENT_AUTHENTICATED event is received
-    Then the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,RESPONDENT_AUTHENTICATED]
+    Then the events logged against the case are [CASE_CREATED,PRINTED_PACK_CODE,RESPONDENT_AUTHENTICATED]

--- a/acceptance_tests/features/sensitive_data.feature
+++ b/acceptance_tests/features/sensitive_data.feature
@@ -4,4 +4,4 @@ Feature: Sample data in the case is sensitive and must be redacted
     Given sample file "sensitive_data_sample.csv" with sensitive column PHONE_NUMBER is loaded successfully
     When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER to 07898787878
     Then the PHONE_NUMBER in the sensitive data on the case has been updated to 07898787878
-    And the events logged against the case are [SAMPLE_LOADED,UPDATE_SAMPLE_SENSITIVE]
+    And the events logged against the case are [CASE_CREATED,UPDATE_SAMPLE_SENSITIVE]

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -7,4 +7,4 @@ Feature: Handle survey launch events
     And UAC_UPDATED messages are emitted with active set to true
     When a SURVEY_LAUNCHED event is received
     Then a CASE_UPDATED message is emitted where "surveyLaunched" is "True"
-    And the events logged against the case are [SAMPLE_LOADED,PRINTED_PACK_CODE,SURVEY_LAUNCHED]
+    And the events logged against the case are [CASE_CREATED,PRINTED_PACK_CODE,SURVEY_LAUNCHED]

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -4,4 +4,4 @@ Feature: Telephone capture
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When there is a request for telephone capture of a case
     Then a UAC and QID with questionnaire type "01" type are generated and returned
-    And the events logged against the case are [SAMPLE_LOADED,TELEPHONE_CAPTURE_REQUESTED]
+    And the events logged against the case are [CASE_CREATED,TELEPHONE_CAPTURE_REQUESTED]


### PR DESCRIPTION
# Motivation and Context
CASE_CREATED & UAC_UPDATED are unused (database) event types.
SAMPLE_LOADED is misleading, because it does not tell us when a sample was loaded, but in fact when we received an instruction to create a case.
We should get rid of SAMPLE_LOADED and UAC_UPDATED and store a CASE_CREATED when we create a case.

# What has changed
Updated features that expected SAMPLE_LOADED event now look for CASE_CREATED event

# How to test?
Build images and run ATs

# Links
https://trello.com/c/JnLxj02F
