### PR TITLE
Move support tool API endpoint

### DIFF
--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -42,7 +42,7 @@ def print_fulfilments_trigger_step(context):
 
 @step("fulfilments are authorised on print template")
 def authorise_pack_code(context):
-    url = f'{Config.SUPPORT_TOOL}/fulfilmentSurveyPrintTemplates'
+    url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyPrintTemplates'
     body = {
         'id': str(uuid.uuid4()),
         'survey': 'surveys/' + context.survey_id,

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -93,7 +93,7 @@ def create_print_template(context, template):
     # We can change/remove this if we get UACS differently or a better solution is found
     context.pack_code = 'pack_code_' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
 
-    url = f'{Config.SUPPORT_TOOL}/printTemplates'
+    url = f'{Config.SUPPORT_TOOL_API}/printTemplates'
     body = {
         'packCode': context.pack_code,
         'printSupplier': 'SUPPLIER_A',

--- a/acceptance_tests/features/steps/sample_loading.py
+++ b/acceptance_tests/features/steps/sample_loading.py
@@ -120,7 +120,7 @@ def upload_sample_file(collex_id, sample_file_path):
         'collectionExerciseId': collex_id,
         'file': ('sample_file', open(sample_file_path, 'rb'), 'text/plain')
     })
-    url = f'{Config.SUPPORT_TOOL}/upload'
+    url = f'{Config.SUPPORT_TOOL_API}/upload'
 
     response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
     response.raise_for_status()

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -7,7 +7,7 @@ from config import Config
 
 
 def create_print_action_rule(collex_id, classifiers, pack_code):
-    url = f'{Config.SUPPORT_TOOL}/actionRules'
+    url = f'{Config.SUPPORT_TOOL_API}/actionRules'
     body = {
         'id': str(uuid.uuid4()),
         'type': 'PRINT',
@@ -24,7 +24,7 @@ def create_print_action_rule(collex_id, classifiers, pack_code):
 
 
 def setup_deactivate_uac_action_rule(collex_id):
-    url = f'{Config.SUPPORT_TOOL}/actionRules'
+    url = f'{Config.SUPPORT_TOOL_API}/actionRules'
     body = {
         'id': str(uuid.uuid4()),
         'type': 'DEACTIVATE_UAC',

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -10,7 +10,7 @@ def add_collex(survey_id):
     collex_id = str(uuid.uuid4())
     collex_name = 'test collex ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 
-    url = f'{Config.SUPPORT_TOOL}/collectionExercises'
+    url = f'{Config.SUPPORT_TOOL_API}/collectionExercises'
     body = {'id': collex_id, 'name': collex_name, 'survey': 'surveys/' + survey_id}
     response = requests.post(url, json=body)
     response.raise_for_status()

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -10,7 +10,7 @@ def add_survey(sample_validation_rules, sample_has_header_row=True, sample_file_
     survey_id = str(uuid.uuid4())
     survey_name = 'test survey ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 
-    url = f'{Config.SUPPORT_TOOL}/surveys'
+    url = f'{Config.SUPPORT_TOOL_API}/surveys'
 
     body = {"id": survey_id,
             "name": survey_name,

--- a/config.py
+++ b/config.py
@@ -40,7 +40,7 @@ class Config:
 
     SUPPORT_TOOL_HOST = os.getenv('SUPPORT_TOOL_HOST', 'localhost')
     SUPPORT_TOOL_PORT = os.getenv('SUPPORT_TOOL_PORT', '9999')
-    SUPPORT_TOOL = f'http://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}'
+    SUPPORT_TOOL_API = f'http://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}/api'
 
     SFTP_HOST = os.getenv('SFTP_HOST', 'localhost')
     SFTP_PORT = os.getenv('SFTP_PORT', '122')


### PR DESCRIPTION
# Motivation and Context
The location of the API endpoint for Support tool has moved to `/api`.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Moved the URL used by the ATs.

# How to test?
Run the ATs.

# Links
Trello: https://trello.com/c/FMznyeqK