### PR TITLE
Fix ATs by pointing at pubsub project

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -72,7 +72,7 @@ spec:
         configMapKeyRef:
           name: project-config
           key: project-name
-    - name: PUBSUB_PROJECT_NAME
+    - name: PUBSUB_PROJECT
       valueFrom:
         configMapKeyRef:
           name: project-config


### PR DESCRIPTION
# Motivation and Context
ATs are broken in the CI pipeline.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Needed to point at the project with the correct env var.

# How to test?
Merge. Run ATs.

# Links
Trello: https://trello.com/c/W86A71JQ