### PR TITLE
Attempt to fix issue with old pubsub messages being double received

### DIFF
--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 
 from google.api_core.exceptions import MethodNotImplemented
 from google.cloud import pubsub_v1
@@ -31,14 +32,15 @@ def _purge_subscription(subscription):
     subscription_path = subscriber.subscription_path(Config.PUBSUB_PROJECT, subscription)
 
     timestamp = Timestamp()
-    timestamp.GetCurrentTime()
+    time_a_bit_in_the_future = datetime.utcnow() + timedelta(minutes=5)
+    timestamp.FromDatetime(time_a_bit_in_the_future)
     try:
         # Try purging via the seek method
         # Seeking to now should ack any messages published before this moment
         subscriber.seek(subscription_path, time=timestamp)
     except MethodNotImplemented:
         # Seek is not implemented by the pubsub-emulator
-        _ack_all_on_subscription()
+        _ack_all_on_subscription(subscriber, subscription_path)
 
 
 def _ack_all_on_subscription(subscriber, subscription_path):


### PR DESCRIPTION
# Motivation and Context
ATs are broken in the pipeline for unknown reasons, but best guess is that the message purge isn't working properly.
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Attempt to purge messages by seeking into the future.

# How to test?
It's impossible, so we need to just merge and try it in the pipeline.

# Links
Trello: https://trello.com/c/NhkaP8wN