### PR TITLE
Another attempt to make the ATs reliable in CI/GCP

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -28,16 +28,16 @@ def before_all(_context):
 
 
 def before_scenario(context, _):
-    context.test_start_local_datetime = datetime.now()
-
     # TODO - this is a hack and should be removed/refactored when we understand better what's going on
     time.sleep(10)
 
     purge_queues()
     purge_fulfilment_triggers()
-
+    
     # TODO - this is a hack and should be removed/refactored when we understand better what's going on
     time.sleep(10)
+
+    context.test_start_local_datetime = datetime.now()
 
 
 def after_all(_context):

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,9 +1,6 @@
 import logging
-from datetime import datetime, timedelta
 
-from google.api_core.exceptions import MethodNotImplemented
 from google.cloud import pubsub_v1
-from google.protobuf.timestamp_pb2 import Timestamp
 from structlog import wrap_logger
 
 from config import Config
@@ -31,16 +28,18 @@ def _purge_subscription(subscription):
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(Config.PUBSUB_PROJECT, subscription)
 
-    timestamp = Timestamp()
-    time_a_bit_in_the_future = datetime.utcnow() + timedelta(minutes=5)
-    timestamp.FromDatetime(time_a_bit_in_the_future)
-    try:
-        # Try purging via the seek method
-        # Seeking to now should ack any messages published before this moment
-        subscriber.seek(subscription_path, time=timestamp)
-    except MethodNotImplemented:
-        # Seek is not implemented by the pubsub-emulator
-        _ack_all_on_subscription(subscriber, subscription_path)
+    # TODO - the seek method should be quick and clean, but it doesn't seem reliable in our GCP CI pipeline
+    # timestamp = Timestamp()
+    # time_a_bit_in_the_future = datetime.utcnow() + timedelta(minutes=5)
+    # timestamp.FromDatetime(time_a_bit_in_the_future)
+    # try:
+    #     # Try purging via the seek method
+    #     # Seeking to now should ack any messages published before this moment
+    #     subscriber.seek(subscription_path, time=timestamp)
+    # except MethodNotImplemented:
+    #     # Seek is not implemented by the pubsub-emulator
+
+    _ack_all_on_subscription(subscriber, subscription_path)
 
 
 def _ack_all_on_subscription(subscriber, subscription_path):


### PR DESCRIPTION
# Motivation and Context
ATs are flakey/unreliable in GCP CI pipeline.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Tried a different technique for purging messages on subscriptions.

# How to test?
Merge and try it.

# Links
Trello: https://trello.com/c/NhkaP8wN