### PR TITLE
Use shared project for shared pubsub topics and subscriptions

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 class Config:
     EVENT_SCHEMA_VERSION = "v0.2_RELEASE"
 
-    PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', 'project')
+    PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', 'shared-project')
     PUBSUB_RECEIPT_TOPIC = os.getenv('PUBSUB_RECEIPT_TOPIC', 'event_receipt')
     PUBSUB_REFUSAL_TOPIC = os.getenv('PUBSUB_REFUSAL_TOPIC', 'event_refusal')
     PUBSUB_INVALID_CASE_TOPIC = os.getenv('PUBSUB_INVALID_CASE_TOPIC',


### PR DESCRIPTION
# Motivation and Context
RM doesn't 'own' the topics and subscriptions which are used to integrate between other products... and as such, they should be kept in a shared project.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Use our own project only for internal messaging, otherwise use a shared project.

# How to test?
Build Case Processor and Support Tool, then start everything up in docker dev with `make up` and then run the acceptance tests with `make test`... should be zero regression.

# Links
Trello: https://trello.com/c/yPZ72ten
