### PR TITLE
Preserve correlation ID and originating user across events

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -50,6 +50,9 @@ Every context attribute used by the tests should be described here.
 | notify_template_id        | Stores the ID of the sms template used for the notify service                   |
 | phone_number              | Stores the phone number needed to check the notify api                          |
 | message_hashes            | Stores the hash of sent messages, for testing exception management              |
+| correlation_id            | Stores the ID which connects all related events together                        |
+| originating_user          | Stores the email of the ONS employee who originally initiated a business event  |
+
 
 ### Sharing Code Between Steps
 

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -36,6 +36,8 @@ def before_scenario(context, _):
     purge_fulfilment_triggers()
 
     context.test_start_local_datetime = datetime.now()
+    context.correlation_id = None
+    context.originating_user = None
 
 
 def after_all(_context):

--- a/acceptance_tests/features/steps/deactivate_uac.py
+++ b/acceptance_tests/features/steps/deactivate_uac.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("a deactivate uac message is put on the queue")
 def put_deactivate_uac_on_topic(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps(
         {
             "header": {
@@ -20,8 +24,8 @@ def put_deactivate_uac_on_topic(context):
                 "channel": "CC",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
-                "correlationId": str(uuid.uuid4()),
-                "originatingUser": "foo@bar.com"
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
             },
             "payload": {
                 "deactivateUac": {

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -7,7 +7,7 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 
 @step("a UAC_UPDATE message is emitted with active set to false")
 def uac_update_msg_emitted(context):
-    emitted_uac = get_emitted_uac_update()
+    emitted_uac = get_emitted_uac_update(context.correlation_id, context.originating_user)
     test_helper.assertEqual(emitted_uac['caseId'], context.emitted_cases[0]['caseId'],
                             'The UAC_UPDATE message case ID must match the first case ID')
     test_helper.assertFalse(emitted_uac['active'], 'The UAC_UPDATE message should active flag "false"')
@@ -15,7 +15,7 @@ def uac_update_msg_emitted(context):
 
 @step('a CASE_UPDATE message is emitted where "{case_field}" is "{expected_field_value}"')
 def case_update_msg_sent_with_values(context, case_field, expected_field_value):
-    emitted_case = get_emitted_case_update()
+    emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user)
 
     test_helper.assertEqual(emitted_case['caseId'], context.emitted_cases[0]['caseId'],
                             'The updated case is expected to be the first stored emitted case')
@@ -25,7 +25,8 @@ def case_update_msg_sent_with_values(context, case_field, expected_field_value):
 
 @step("UAC_UPDATE messages are emitted with active set to {active:boolean}")
 def check_uac_update_msgs_emitted_with_qid_active(context, active):
-    context.emitted_uacs = get_uac_update_events(len(context.emitted_cases))
+    context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
+                                                 context.originating_user)
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
 
     _check_new_uacs_are_as_expected(context.emitted_uacs, active)
@@ -33,7 +34,7 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 
 @step("{expected_count:d} UAC_UPDATE messages are emitted with active set to {active:boolean}")
 def check_expected_number_of_uac_update_msgs_emitted(context, expected_count, active):
-    context.emitted_uacs = get_uac_update_events(expected_count)
+    context.emitted_uacs = get_uac_update_events(expected_count, context.correlation_id, context.originating_user)
 
     _check_new_uacs_are_as_expected(context.emitted_uacs, active)
 

--- a/acceptance_tests/features/steps/invalid_case.py
+++ b/acceptance_tests/features/steps/invalid_case.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("an INVALID_CASE event is received")
 def send_invalid_case_msg(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps(
         {
             "header": {
@@ -20,8 +24,8 @@ def send_invalid_case_msg(context):
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
-                "correlationId": str(uuid.uuid4()),
-                "originatingUser": "foo@bar.com"
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
             },
             "payload": {
                 "invalidCase": {

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -6,6 +6,7 @@ from time import sleep
 import requests
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.database_helper import open_cursor
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
@@ -23,7 +24,7 @@ def request_print_fulfilment_step(context):
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
                 "correlationId": str(uuid.uuid4()),
-                "originatingUser": "foo@bar.com"
+                "originatingUser": get_unique_user_email()
             },
             "payload": {
                 "printFulfilment": {

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("a receipt message is published to the pubsub receipting topic")
 def send_receipt(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps({
         "header": {
             "version": Config.EVENT_SCHEMA_VERSION,
@@ -19,8 +23,8 @@ def send_receipt(context):
             "channel": "RH",
             "dateTime": f'{datetime.utcnow().isoformat()}Z',
             "messageId": str(uuid.uuid4()),
-            "correlationId": str(uuid.uuid4()),
-            "originatingUser": "foo@bar.com"
+            "correlationId": context.correlation_id,
+            "originatingUser": context.originating_user
         },
         "payload": {
             "receipt": {

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("a REFUSAL event is received")
 def send_refusal_msg(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps(
         {
             "header": {
@@ -20,8 +24,8 @@ def send_refusal_msg(context):
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
-                "correlationId": str(uuid.uuid4()),
-                "originatingUser": "foo@bar.com"
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
             },
             "payload": {
                 "refusal": {

--- a/acceptance_tests/features/steps/respondent_authenticated.py
+++ b/acceptance_tests/features/steps/respondent_authenticated.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("a UAC_AUTHENTICATION event is received")
 def send_respondent_authenticated_msg(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps(
         {
             "header": {
@@ -20,7 +24,8 @@ def send_respondent_authenticated_msg(context):
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
-                "correlationId": str(uuid.uuid4())
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
             },
             "payload": {
                 "uacAuthentication": {

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -6,6 +6,7 @@ import uuid
 import requests
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -27,14 +28,16 @@ def authorise_sms_pack_code(context):
 def request_replacement_uac_by_sms(context, phone_number):
     requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
     context.phone_number = phone_number
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
 
     url = f'{Config.NOTIFY_SERVICE_API}sms-fulfilment'
     body = {
         "header": {
             "source": "CC",
             "channel": "CC",
-            "correlationId": str(uuid.uuid4()),
-            "originatingUser": "foo@bar.com"
+            "correlationId": context.correlation_id,
+            "originatingUser": context.originating_user
         },
         "payload": {
             "smsFulfilment": {

--- a/acceptance_tests/features/steps/survey_launched.py
+++ b/acceptance_tests/features/steps/survey_launched.py
@@ -5,12 +5,16 @@ from datetime import datetime
 
 from behave import step
 
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
 @step("a SURVEY_LAUNCH event is received")
 def send_survey_launched_msg(context):
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = get_unique_user_email()
+
     message = json.dumps(
         {
             "header": {
@@ -20,7 +24,8 @@ def send_survey_launched_msg(context):
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
                 "messageId": str(uuid.uuid4()),
-                "correlationId": str(uuid.uuid4())
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
             },
             "payload": {
                 "surveyLaunch": {

--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -1,0 +1,9 @@
+import random
+import string
+
+
+def get_unique_user_email():
+    name_part = ''.join(random.choices(string.ascii_lowercase, k=5))
+    domain_part = ''.join(random.choices(string.ascii_lowercase, k=5))
+    tld_part = ''.join(random.choices(["com", "org", "gov.uk", "io"]))
+    return f'{name_part}@{domain_part}.{tld_part}'

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -15,7 +15,11 @@ def get_emitted_cases(expected_msg_count=1):
     test_helper.assertEqual(len(messages_received), expected_msg_count,
                             'Did not find expected number of events')
 
-    case_payloads = [message_received['payload']['caseUpdate'] for message_received in messages_received]
+    case_payloads = []
+    for message_received in messages_received:
+        test_helper.assertEqual(message_received['header']['originatingUser'], Config.SAMPLE_LOAD_ORIGINATING_USER,
+                                'Unexpected originating user')
+        case_payloads.append(message_received['payload']['caseUpdate'])
 
     return case_payloads
 
@@ -56,7 +60,7 @@ def _attempt_to_get_expected_number_of_messages(subscriber, subscription_path, e
     return messages
 
 
-def get_emitted_case_update():
+def get_emitted_case_update(correlation_id, originating_user):
     messages_received = []
     start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
                                            message_list=messages_received,
@@ -64,10 +68,18 @@ def get_emitted_case_update():
 
     test_helper.assertEqual(len(messages_received), 1, 'Expected to receive one and only one CASE_UPDATE message')
 
+    if correlation_id:
+        test_helper.assertEqual(messages_received[0]['header']['correlationId'], correlation_id,
+                                'Unexpected correlation ID')
+
+    if originating_user:
+        test_helper.assertEqual(messages_received[0]['header']['originatingUser'], originating_user,
+                                'Unexpected originating user')
+
     return messages_received[0]['payload']['caseUpdate']
 
 
-def get_emitted_uac_update():
+def get_emitted_uac_update(correlation_id, originating_user):
     messages_received = []
     start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                            message_list=messages_received,
@@ -75,14 +87,32 @@ def get_emitted_uac_update():
 
     test_helper.assertEqual(len(messages_received), 1, 'Expected to receive one and only one UAC_UPDATE message')
 
+    if correlation_id:
+        test_helper.assertEqual(messages_received[0]['header']['correlationId'], correlation_id,
+                                'Unexpected correlation ID')
+
+    if originating_user:
+        test_helper.assertEqual(messages_received[0]['header']['originatingUser'], originating_user,
+                                'Unexpected originating user')
+
     return messages_received[0]['payload']['uacUpdate']
 
 
-def get_uac_update_events(expected_number):
+def get_uac_update_events(expected_number, correlation_id, originating_user):
     messages_received = []
     start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                            message_list=messages_received,
                                            expected_msg_count=expected_number)
+    uac_payloads = []
+    for uac_event in messages_received:
+        if correlation_id:
+            test_helper.assertEqual(uac_event['header']['correlationId'], correlation_id,
+                                    'Unexpected correlation ID')
 
-    uac_payloads = [uac_event['payload']['uacUpdate'] for uac_event in messages_received]
+        if originating_user:
+            test_helper.assertEqual(uac_event['header']['originatingUser'], originating_user,
+                                    'Unexpected originating user')
+
+        uac_payloads.append(uac_event['payload']['uacUpdate'])
+
     return uac_payloads

--- a/config.py
+++ b/config.py
@@ -65,3 +65,5 @@ class Config:
     CASE_API_CASE_URL = f'{CASEAPI_SERVICE}/cases/'
 
     RESOURCE_FILE_PATH = Path(os.getenv('RESOURCE_FILE_PATH') or Path(__file__).parent.joinpath('resources'))
+
+    SAMPLE_LOAD_ORIGINATING_USER = os.getenv('ORIGINATING_USER', 'dummy@fake-email.com')


### PR DESCRIPTION
# Motivation and Context
Correlation IDs are incredibly useful for audit trail, digital forensics, debugging and diagnosing defects, "identifying training opportunities" and suchlike. They only work if they truly correlate related events together, end-to-end.

Likewise, having an audit trail of the originating user - where it's known - is useful too, and saves a lot of hassle trawling through load balancer logs, trying to figure out who initiated a particular chain of events.

* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Preserved the correlation ID and originating user, where it's known, across events and other cascading effects from the original cause.

# How to test?
Use the support tool to create various types of event (e.g. refusal, receipt etc) and check that the resulting case and UAC updates have the correlation ID on them, and originating user (where appropriate).

# Links
Trello: https://trello.com/c/ESjv6BOa