### PR TITLE
Fix exception manager tests which are slow and flakey

### DIFF
--- a/acceptance_tests/utilities/exception_manager_helper.py
+++ b/acceptance_tests/utilities/exception_manager_helper.py
@@ -8,7 +8,7 @@ def quarantine_bad_messages(bad_message_hashes):
         response = requests.get(f"{Config.EXCEPTION_MANAGER_URL}/skipmessage/{message_hash}")
         response.raise_for_status()
 
-    time.sleep(1)
+    time.sleep(3)
     requests.get(f'{Config.EXCEPTION_MANAGER_URL}/reset')
 
 


### PR DESCRIPTION
# Motivation and Context
The ATs which check the exception manager are working, are adding loads of time to the AT test run, and are not at all reliable.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Used a retry instead of arbitrary sleep. Also, reduced sleeps for quarantining messages.

# How to test?
Run ATs... but this is mainly to improve things in CI, so we should try this and fail forwards.

# Links
Trello: https://trello.com/c/1MyWuNyW