### PR TITLE
2707 SMS fulfilment request returns UAC Hash and QID

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -37,23 +37,22 @@ def step_to_do_a_thing(context):
 
 Every context attribute used by the tests should be described here.
 
-| Attribute                 | Description                                                                     |
-| ------------------------- | ------------------------------------------------------------------------------- |
-| test_start_local_datetime | Stores the local time at the beginning of each scenario in an environment hook  |
-| survey_id                 | Stores the ID of the survey generated and or used by the scenario               |
-| collex_id                 | Stores the ID of the collection exercise generated and or used by the scenario  |
-| emitted_cases             | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events               |
-| emitted_uacs              | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                 |
-| pack_code                 | Stores the pack code used for fulfilments or action rules                       |
-| template                  | Stores the column template used for fulfilments or action rules                 |
-| telephone_capture_request | Stores the UAC and QID returned by a telephone capture API call                 |
-| notify_template_id        | Stores the ID of the sms template used for the notify service                   |
-| sms_fulfilment_response   | Stores the response JSON from a `POST` to the Notify API                        |
-| phone_number              | Stores the phone number needed to check the notify api                          |
-| message_hashes            | Stores the hash of sent messages, for testing exception management              |
-| correlation_id            | Stores the ID which connects all related events together                        |
-| originating_user          | Stores the email of the ONS employee who originally initiated a business event  |
-
+| Attribute                    | Description                                                                     |
+| -------------------------    | ------------------------------------------------------------------------------- |
+| test_start_local_datetime    | Stores the local time at the beginning of each scenario in an environment hook  |
+| survey_id                    | Stores the ID of the survey generated and or used by the scenario               |
+| collex_id                    | Stores the ID of the collection exercise generated and or used by the scenario  |
+| emitted_cases                | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events               |
+| emitted_uacs                 | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                 |
+| pack_code                    | Stores the pack code used for fulfilments or action rules                       |
+| template                     | Stores the column template used for fulfilments or action rules                 |
+| telephone_capture_request    | Stores the UAC and QID returned by a telephone capture API call                 |
+| notify_template_id           | Stores the ID of the sms template used for the notify service                   |
+| sms_fulfilment_response_json | Stores the response JSON from a `POST` to the Notify API                        |
+| phone_number                 | Stores the phone number needed to check the notify api                          |
+| message_hashes               | Stores the hash of sent messages, for testing exception management              |
+| correlation_id               | Stores the ID which connects all related events together                        |
+| originating_user             | Stores the email of the ONS employee who originally initiated a business event  |
 
 ### Sharing Code Between Steps
 

--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -48,6 +48,7 @@ Every context attribute used by the tests should be described here.
 | template                  | Stores the column template used for fulfilments or action rules                 |
 | telephone_capture_request | Stores the UAC and QID returned by a telephone capture API call                 |
 | notify_template_id        | Stores the ID of the sms template used for the notify service                   |
+| sms_fulfilment_response   | Stores the response JSON from a `POST` to the Notify API                        |
 | phone_number              | Stores the phone number needed to check the notify api                          |
 | message_hashes            | Stores the hash of sent messages, for testing exception management              |
 | correlation_id            | Stores the ID which connects all related events together                        |
@@ -62,7 +63,7 @@ the same file, or the shared code should be factored out into the utilities modu
 ### Step wording
 
 Steps should be written in full and concise sentences, avoiding unnecessary abbreviations and shorthand. They should be
-as understandable and non-technical possible.
+as understandable and as non-technical as possible.
 
 ### Assertions
 

--- a/acceptance_tests/features/sms_fulfilment.feature
+++ b/acceptance_tests/features/sms_fulfilment.feature
@@ -6,6 +6,7 @@ Feature: Sms fulfilment
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true
+    And the UAC_UPDATE message matches the SMS fulfilment UAC
     And the events logged against the case are [NEW_CASE,SMS_FULFILMENT]
     And notify api was called with SMS template
 

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -53,10 +53,10 @@ def request_replacement_uac_by_sms(context, phone_number):
 
     context.sms_fulfilment_response = response.json()
 
-    _check_sms_fulfilment_response_from_template(context.sms_fulfilment_response, context.template)
+    _check_sms_fulfilment_response(context.sms_fulfilment_response, context.template)
 
 
-def _check_sms_fulfilment_response_from_template(sms_fulfilment_response, template):
+def _check_sms_fulfilment_response(sms_fulfilment_response, template):
     expect_uac_hash_and_qid_in_response = any(
         template_item in json.loads(template) for template_item in ['__qid__', '__uac__'])
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

The Notify API now returns from a `POST /sms-fulfilment` either: 
* a UAC Hash and QID if the created template has either a `__qid__` or `__uac__`, or
* an empty JSON `{}`  if the template does not contain either of these values

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated existing tests to check for UAC and non-UAC scenarios using the Notify API

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run off the other repo in this ticket

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/THkuyUrE/2707-notify-service-api-should-return-a-uachash-and-qid-so-that-rh-can-immediately-persist-and-the-respondent-can-launch-5)