### PR TITLE
2754 Fix pubsub pull behaviour flakiness

### DIFF
--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -39,7 +39,7 @@ def send_refusal_msg(context):
 
 
 @step("a bad REFUSAL event is put on the topic")
-def step_impl(context):
+def send_bad_refusal_message(context):
     message = json.dumps(
         {
             "header": {
@@ -54,6 +54,7 @@ def step_impl(context):
             },
             "payload": {
                 "refusal": {
+                    # This case will not exist
                     "caseId": "1c1e495d-8f49-4d4c-8318-6174454eb605",
                     "type": "EXTRAORDINARY_REFUSAL"
                 }

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -16,23 +16,6 @@ def get_emitted_cases(expected_msg_count=1):
     return case_payloads
 
 
-# def _attempt_to_get_expected_number_of_messages(subscriber, subscription_path, expected_msg_count):
-#     messages = []
-#     remaining_messages_to_get = expected_msg_count
-#     last_one = False
-#
-#     while remaining_messages_to_get and not last_one:
-#         if remaining_messages_to_get == 1:
-#             last_one = True
-#
-#         response = subscriber.pull(subscription_path, max_messages=remaining_messages_to_get, timeout=30)
-#
-#         messages += response.received_messages
-#         remaining_messages_to_get -= len(response.received_messages)
-#
-#     return messages
-
-
 def get_emitted_case_update(correlation_id, originating_user):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
                                                             expected_msg_count=1)

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -1,20 +1,11 @@
-import json
-
-from google.cloud import pubsub_v1
-from tenacity import retry, stop_after_delay, wait_fixed
-
+from acceptance_tests.utilities.pubsub_helper import get_exact_number_of_pubsub_messages
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
 def get_emitted_cases(expected_msg_count=1):
-    messages_received = []
-    start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                           message_list=messages_received,
-                                           expected_msg_count=expected_msg_count)
-
-    test_helper.assertEqual(len(messages_received), expected_msg_count,
-                            'Did not find expected number of events')
+    messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
+                                                            expected_msg_count=expected_msg_count)
 
     case_payloads = []
     for message_received in messages_received:
@@ -25,49 +16,26 @@ def get_emitted_cases(expected_msg_count=1):
     return case_payloads
 
 
-def start_listening_to_pubsub_subscription(subscription, expected_msg_count, message_list):
-    subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(Config.PUBSUB_PROJECT,
-                                                     subscription)
-    received_messages = _attempt_to_get_expected_number_of_messages(subscriber, subscription_path, expected_msg_count)
-
-    ack_ids = []
-
-    for received_message in received_messages:
-        parsed_body = json.loads(received_message.message.data)
-        message_list.append(parsed_body)
-        ack_ids.append(received_message.ack_id)
-
-    if ack_ids:
-        subscriber.acknowledge(subscription_path, ack_ids)
-
-    subscriber.close()
-
-
-def _attempt_to_get_expected_number_of_messages(subscriber, subscription_path, expected_msg_count):
-    messages = []
-    remaining_messages_to_get = expected_msg_count
-    last_one = False
-
-    while remaining_messages_to_get and not last_one:
-        if remaining_messages_to_get == 1:
-            last_one = True
-
-        response = subscriber.pull(subscription_path, max_messages=remaining_messages_to_get, timeout=30)
-
-        messages += response.received_messages
-        remaining_messages_to_get -= len(response.received_messages)
-
-    return messages
+# def _attempt_to_get_expected_number_of_messages(subscriber, subscription_path, expected_msg_count):
+#     messages = []
+#     remaining_messages_to_get = expected_msg_count
+#     last_one = False
+#
+#     while remaining_messages_to_get and not last_one:
+#         if remaining_messages_to_get == 1:
+#             last_one = True
+#
+#         response = subscriber.pull(subscription_path, max_messages=remaining_messages_to_get, timeout=30)
+#
+#         messages += response.received_messages
+#         remaining_messages_to_get -= len(response.received_messages)
+#
+#     return messages
 
 
 def get_emitted_case_update(correlation_id, originating_user):
-    messages_received = []
-    start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                           message_list=messages_received,
-                                           expected_msg_count=1)
-
-    test_helper.assertEqual(len(messages_received), 1, 'Expected to receive one and only one CASE_UPDATE message')
+    messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
+                                                            expected_msg_count=1)
 
     if correlation_id:
         test_helper.assertEqual(messages_received[0]['header']['correlationId'], correlation_id,
@@ -81,12 +49,8 @@ def get_emitted_case_update(correlation_id, originating_user):
 
 
 def get_emitted_uac_update(correlation_id, originating_user):
-    messages_received = []
-    start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
-                                           message_list=messages_received,
-                                           expected_msg_count=1)
-
-    test_helper.assertEqual(len(messages_received), 1, 'Expected to receive one and only one UAC_UPDATE message')
+    messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
+                                                            expected_msg_count=1)
 
     if correlation_id:
         test_helper.assertEqual(messages_received[0]['header']['correlationId'], correlation_id,
@@ -99,15 +63,10 @@ def get_emitted_uac_update(correlation_id, originating_user):
     return messages_received[0]['payload']['uacUpdate']
 
 
-@retry(wait=wait_fixed(1), stop=stop_after_delay(30))
 def get_uac_update_events(expected_number, correlation_id, originating_user):
-    messages_received = []
-    start_listening_to_pubsub_subscription(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
-                                           message_list=messages_received,
-                                           expected_msg_count=expected_number)
-
-    test_helper.assertEqual(len(messages_received), expected_number,
-                            f'Expected to receive {expected_number} UAC_UPDATE message(s)')
+    messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
+                                                            expected_msg_count=expected_number,
+                                                            timeout=60)
 
     uac_payloads = []
     for uac_event in messages_received:

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -71,7 +71,7 @@ def _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_c
 
     # The PubSub subscriber client does not wait the full duration of its timeout before returning if it finds just
     # at least one message. To work around this, we loop pulling messages repeatedly within our own timeout to allow
-    # the full time for all the expected messages to be published and pulled 
+    # the full time for all the expected messages to be published and pulled
     while len(received_messages) < expected_msg_count and not time.time() > deadline:
         try:
             response = subscriber.pull(subscription_path, max_messages=expected_msg_count, timeout=1)
@@ -83,7 +83,7 @@ def _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_c
 
     test_helper.assertEqual(len(received_messages), expected_msg_count,
                             f'Expected to pull exactly {expected_msg_count} message(s) from '
-                            f'subscription {subscription_path} but only found {len(received_messages)} '
+                            f'subscription {subscription_path} but found {len(received_messages)} '
                             f'within the {timeout} second timeout')
     return received_messages
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -70,9 +70,9 @@ def _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_c
     deadline = time.time() + timeout
 
     while len(messages) < expected_msg_count and not time.time() > deadline:
-        # Why not just set the `max_messages` in the subscriber.pull call to the expected number? Because the client
-        # will not wait for the timeout before returning if it finds just at least one message, where we want to
-        # instead allow the full time for all the expected messages time to be published and pulled
+        # Why not just set the `max_messages` in the subscriber.pull call to the expected number? Because the
+        # subscriber client does not wait for the timeout before returning if it finds just at least one message,
+        # where we want to instead allow the full time for all the expected messages time to be published and pulled
         response = subscriber.pull(subscription_path, return_immediately=True, max_messages=1)
         messages.extend(response.received_messages)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
The pubsub subscriber client does not behave as we expected/wished when pulling a number of messages, we instead need to use our own logic to allow it to pull an expected number within a timeout.

# What has changed
- Rewrite pubsub pull expected number of messages code

# How to test?
Run locally to check it functions. The real test will be reliability over time in CI.

# Links
https://trello.com/c/0XbDXZ0q/2754-ats-are-flakey-in-gcp-ci