### PR TITLE
Record user who quarantined message for audit trail

### DIFF
--- a/acceptance_tests/utilities/exception_manager_helper.py
+++ b/acceptance_tests/utilities/exception_manager_helper.py
@@ -1,11 +1,18 @@
 import time
 import requests
+
+from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from config import Config
 
 
 def quarantine_bad_messages(bad_message_hashes):
     for message_hash in bad_message_hashes:
-        response = requests.get(f"{Config.EXCEPTION_MANAGER_URL}/skipmessage/{message_hash}")
+        skip_request = {
+            "messageHash": message_hash,
+            "skippingUser": get_unique_user_email()
+        }
+
+        response = requests.post(f"{Config.EXCEPTION_MANAGER_URL}/skipmessage", json=skip_request)
         response.raise_for_status()
 
     time.sleep(3)


### PR DESCRIPTION
# Motivation and Context
We want an audit trail of who quarantined messages.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Did a best attempt at linking the user who originally requested that a message be 'skipped' to the eventual implementation of that request by the Exception Manager. User is recorded in a `skipping_user` database column in the `quarantined_message` table.

# How to test?
Create a bad message, either using the docker dev `publish_message.sh` script locally, or by publishing directly to a topic in GCP. Then, use the support tool to skip a message. Also, try skipping a message using the toolbox bad message wizard. Check the database - it should have recorded the user who skipped the message!

# Links
Trello: https://trello.com/c/JNPHZeos