### PR TITLE
2772 Print fulfilment check events instead of sleep

### DIFF
--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -5,6 +5,7 @@ Feature: Print fulfilments can be requested for a case
     And a print template has been created with template "["ADDRESS_LINE1","POSTCODE","__uac__"]"
     And fulfilments are authorised on print template
     And a print fulfilment has been requested
+    And the events logged against the case are [NEW_CASE,PRINT_FULFILMENT]
     When print fulfilments are triggered to be sent for printing
     Then UAC_UPDATE messages are emitted with active set to true
     And a print file is created with correct rows

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -34,9 +34,6 @@ def request_print_fulfilment_step(context):
         })
     publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_PRINT_FULFILMENT_TOPIC)
 
-    # TODO - maybe trigger the fulfilments a few seconds in the future instead, but this should work for now, I hope!
-    sleep(2)
-
 
 @step('print fulfilments are triggered to be sent for printing')
 def print_fulfilments_trigger_step(context):

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from datetime import datetime
-from time import sleep
 
 import requests
 from behave import step

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -5,7 +5,8 @@ from config import Config
 
 def get_emitted_cases(expected_msg_count=1):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                                            expected_msg_count=expected_msg_count)
+                                                            expected_msg_count=expected_msg_count,
+                                                            timeout=60)
 
     case_payloads = []
     for message_received in messages_received:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

We can check the fulfilment event is logged against the case before triggering the print fulfilments to be processed, instead of an arbitrary sleep time.

Also we've been seeing a sample load timeout at the start of tests, so try bumping that to 60 seconds.

# What has changed
- Check case events for print fulfilment before triggering instead of arbitrary sleep
- Increase timeout on getting emitted cases from sample load to 60 seconds

# How to test?
Run the ATs locally

# Links
https://trello.com/c/ZUpLOaGd/2772-at-print-fulfilment-improvements-3