### PR TITLE
rename survey launch to eq launch

### DIFF
--- a/acceptance_tests/features/exception_manager.feature
+++ b/acceptance_tests/features/exception_manager.feature
@@ -35,7 +35,7 @@ Feature: Check exception manager is called for every topic and handles them as e
     Then a bad message appears in exception manager with exception message containing "Case ID '386a50b8-6ba0-40f6-bd3c-34333d58be90' not present"
     And each bad msg can be successfully quarantined
 
-  Scenario: Bad survey launched message turns up in exception manager
-    When a bad survey launched event is put on the topic
+  Scenario: Bad EQ launched message turns up in exception manager
+    When a bad EQ launched event is put on the topic
     Then a bad message appears in exception manager with exception message containing "Questionnaire Id '555555' not found!"
     And each bad msg can be successfully quarantined

--- a/acceptance_tests/features/steps/eq_launched.py
+++ b/acceptance_tests/features/steps/eq_launched.py
@@ -10,8 +10,8 @@ from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from config import Config
 
 
-@step("a SURVEY_LAUNCH event is received")
-def send_survey_launched_msg(context):
+@step("an EQ_LAUNCH event is received")
+def send_eq_launched_msg(context):
     context.correlation_id = str(uuid.uuid4())
     context.originating_user = get_unique_user_email()
 
@@ -19,7 +19,7 @@ def send_survey_launched_msg(context):
         {
             "header": {
                 "version": Config.EVENT_SCHEMA_VERSION,
-                "topic": Config.PUBSUB_SURVEY_LAUNCH_TOPIC,
+                "topic": Config.PUBSUB_EQ_LAUNCH_TOPIC,
                 "source": "RH",
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
@@ -28,23 +28,23 @@ def send_survey_launched_msg(context):
                 "originatingUser": context.originating_user
             },
             "payload": {
-                "surveyLaunch": {
+                "eqLaunch": {
                     "qid": context.emitted_uacs[0]['qid']
                 }
             }
         }
     )
 
-    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_SURVEY_LAUNCH_TOPIC)
+    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_EQ_LAUNCH_TOPIC)
 
 
-@step("a bad survey launched event is put on the topic")
+@step("a bad EQ launched event is put on the topic")
 def step_impl(context):
     message = json.dumps(
         {
             "header": {
                 "version": Config.EVENT_SCHEMA_VERSION,
-                "topic": Config.PUBSUB_SURVEY_LAUNCH_TOPIC,
+                "topic": Config.PUBSUB_EQ_LAUNCH_TOPIC,
                 "source": "RH",
                 "channel": "RH",
                 "dateTime": f'{datetime.utcnow().isoformat()}Z',
@@ -52,12 +52,12 @@ def step_impl(context):
                 "correlationId": str(uuid.uuid4())
             },
             "payload": {
-                "surveyLaunch": {
+                "eqLaunch": {
                     "qid": "555555"
                 }
             }
         }
     )
 
-    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_SURVEY_LAUNCH_TOPIC)
+    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_EQ_LAUNCH_TOPIC)
     context.message_hashes = [hashlib.sha256(message.encode('utf-8')).hexdigest()]

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -1,10 +1,10 @@
-Feature: Handle survey launch events
+Feature: Handle EQ launch events
 
-  Scenario: Survey launched events are logged and the case flag is updated
+  Scenario: EQ launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     And a print template has been created with template "["__uac__"]"
     And a print action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
-    When a SURVEY_LAUNCH event is received
-    Then a CASE_UPDATE message is emitted where "surveyLaunched" is "True"
-    And the events logged against the case are [NEW_CASE,PRINT_FILE,SURVEY_LAUNCH]
+    When an EQ_LAUNCH event is received
+    Then a CASE_UPDATE message is emitted where "eqLaunched" is "True"
+    And the events logged against the case are [NEW_CASE,PRINT_FILE,EQ_LAUNCH]

--- a/config.py
+++ b/config.py
@@ -12,8 +12,8 @@ class Config:
     PUBSUB_INVALID_CASE_TOPIC = os.getenv('PUBSUB_INVALID_CASE_TOPIC',
                                           'event_invalid-case')
     PUBSUB_PRINT_FULFILMENT_TOPIC = os.getenv('PUBSUB_PRINT_FULFILMENT_TOPIC', 'event_print-fulfilment')
-    PUBSUB_SURVEY_LAUNCH_TOPIC = os.getenv('PUBSUB_SURVEY_LAUNCH_TOPIC',
-                                           'event_survey-launch')
+    PUBSUB_EQ_LAUNCH_TOPIC = os.getenv('PUBSUB_EQ_LAUNCH_TOPIC',
+                                       'event_eq-launch')
     PUBSUB_UAC_AUTHENTICATION_TOPIC = os.getenv('PUBSUB_UAC_AUTHENTICATION_TOPIC',
                                                 'event_uac-authentication')
     PUBSUB_DEACTIVATE_UAC_TOPIC = os.getenv('PUBSUB_DEACTIVATE_UAC_TOPIC', 'event_deactivate-uac')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
"survey launch" is misleading, because a survey is a set of collection exercises, and a set of collection instruments... what we're really talking about is a specific electronic questionnaire launch (which could be either Blaise or EQ).
We need to rename the topic, subscription, listener in case processor and all associated gubbins.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Survey launch has been changed to eq launch in all occurrences
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
`shift-ctrl-f` for surveyLaunch(ed), survey-launch, survey_launch - should be zero occurrences
Run the ATs using all the other services on the ticket built on the branches
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/hOoco1AN/2752-rename-surveylaunch-to-eqlaunch-5
# Screenshots (if appropriate):
