### PR TITLE
2668 move receipt to uac

### DIFF
--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -4,6 +4,7 @@ Feature: Handle EQ launch events
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     And a print template has been created with template "["__uac__"]"
     And a print action rule has been created
-    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
+    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     When an EQ_LAUNCH event is received
+    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
     And the events logged against the case are [NEW_CASE,PRINT_FILE,EQ_LAUNCH]

--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -4,7 +4,6 @@ Feature: Handle EQ launch events
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     And a print template has been created with template "["__uac__"]"
     And a print action rule has been created
-    And UAC_UPDATE messages are emitted with active set to true
+    Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
     When an EQ_LAUNCH event is received
-    Then a CASE_UPDATE message is emitted where "eqLaunched" is "True"
     And the events logged against the case are [NEW_CASE,PRINT_FILE,EQ_LAUNCH]

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -6,6 +6,5 @@ Feature: A case can be receipted with an event
     And a print action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic
-    Then a UAC_UPDATE message is emitted with active set to false
-    And a CASE_UPDATE message is emitted where "receiptReceived" is "True"
+    Then UAC_UPDATE message is emitted with active set to false and "receiptReceived" is true
     And the events logged against the case are [NEW_CASE,PRINT_FILE,RECEIPT]

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -35,12 +35,12 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 
 
 @step(
-    'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is {expected_value:boolean}')
+    'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
+    ' {expected_value:boolean}')
 def check_uac_update_msgs_emitted_with_qid_active(context, active, field_to_test, expected_value):
     context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
                                                  context.originating_user)
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
-
     _check_new_uacs_are_as_expected(context.emitted_uacs, active, field_to_test, expected_value)
 
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -37,7 +37,8 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 @step(
     'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
     ' {expected_value:boolean}')
-def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context, active, field_to_test, expected_value):
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context, active,
+                                                                         field_to_test, expected_value):
     context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
                                                  context.originating_user)
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -37,7 +37,7 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 @step(
     'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
     ' {expected_value:boolean}')
-def check_uac_update_msgs_emitted_with_qid_active(context, active, field_to_test, expected_value):
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context, active, field_to_test, expected_value):
     context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
                                                  context.originating_user)
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -34,6 +34,16 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
     _check_new_uacs_are_as_expected(context.emitted_uacs, active)
 
 
+@step(
+    'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is {expected_value:boolean}')
+def check_uac_update_msgs_emitted_with_qid_active(context, active, field_to_test, expected_value):
+    context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
+                                                 context.originating_user)
+    _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
+
+    _check_new_uacs_are_as_expected(context.emitted_uacs, active, field_to_test, expected_value)
+
+
 @step("{expected_count:d} UAC_UPDATE messages are emitted with active set to {active:boolean}")
 def check_expected_number_of_uac_update_msgs_emitted(context, expected_count, active):
     context.emitted_uacs = get_uac_update_events(expected_count, context.correlation_id, context.originating_user)
@@ -46,9 +56,13 @@ def check_expected_number_of_uac_update_msgs_emitted(context, expected_count, ac
     context.emitted_cases = [case for case in context.emitted_cases if case['caseId'] in included_case_ids]
 
 
-def _check_new_uacs_are_as_expected(emitted_uacs, active):
+def _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test=None, expected_value=None):
     for uac in emitted_uacs:
-        test_helper.assertEqual(uac['active'], active)
+        test_helper.assertEqual(uac['active'], active, f"UAC {uac} active status doesn't equal expected {active}")
+
+        if field_to_test:
+            test_helper.assertEqual(uac[field_to_test], expected_value,
+                                    f"UAC {uac} field {field_to_test} doesn't equal expected {expected_value}")
 
 
 def _check_uacs_updated_match_cases(uac_update_events, cases):

--- a/acceptance_tests/utilities/case_api_helper.py
+++ b/acceptance_tests/utilities/case_api_helper.py
@@ -19,4 +19,5 @@ def check_if_event_list_is_exact_match(event_type_list, case_id):
     actual_logged_event_types = [event['eventType'] for event in actual_logged_events]
 
     test_helper.assertCountEqual(expected_logged_event_types, actual_logged_event_types,
-                                 msg="Actual logged event types did not match expected")
+                                 msg=f"Actual logged event types {actual_logged_event_types} "
+                                     f"did not match expected {expected_logged_event_types}")


### PR DESCRIPTION
# Motivation and Context
Updating to schema 0.3,  mainly receipt & launched moving from case to uac


# What has changed
Altered the tests


# How to test?
With the other apps from this ticket installed

# Links
https://trello.com/c/NmU4RIZW/2668-json-schema-v03-release-case-update-receipted-launched-to-be-on-uacupdate-not-caseupdate-8

# Screenshots (if appropriate):