### PR TITLE
Add mandatory sample definition URL when creating surveys

### DIFF
--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -65,3 +65,10 @@ def get_uac_update_events(expected_number, correlation_id, originating_user):
         uac_payloads.append(uac_event['payload']['uacUpdate'])
 
     return uac_payloads
+
+
+def get_emitted_survey_update():
+    message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
+                                                           expected_msg_count=1)[0]
+
+    return message_received['payload']['surveyUpdate']

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 import requests
 
+from acceptance_tests.utilities.event_helper import get_emitted_survey_update
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
@@ -14,10 +16,20 @@ def add_survey(sample_validation_rules, sample_has_header_row=True, sample_file_
             "sampleValidationRules": sample_validation_rules,
             "sampleWithHeaderRow": sample_has_header_row,
             "sampleSeparator": sample_file_separator,
-            "sampleDefinitionUrl": "http://foo.bar"}
+            "sampleDefinitionUrl": "http://foo.bar",
+            "metadata": {'foo': 'bar'}}
 
     response = requests.post(url, json=body)
     response.raise_for_status()
 
     survey_id = response.json()
+
+    survey_update_event = get_emitted_survey_update()
+    test_helper.assertEqual(survey_update_event['name'], survey_name,
+                            'Unexpected survey name')
+    test_helper.assertEqual(survey_update_event['sampleDefinitionUrl'], "http://foo.bar",
+                            'Unexpected sample definition URL')
+    test_helper.assertEqual(survey_update_event['metadata'], {'foo': 'bar'},
+                            'Unexpected metadata')
+
     return survey_id

--- a/config.py
+++ b/config.py
@@ -21,6 +21,7 @@ class Config:
                                                      'event_update-sample-sensitive')
     PUBSUB_OUTBOUND_UAC_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_UAC_SUBSCRIPTION', 'event_uac-update_rh')
     PUBSUB_OUTBOUND_CASE_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_CASE_SUBSCRIPTION', 'event_case-update_rh')
+    PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION', 'event_survey-update_rh')
     PUBSUB_NEW_CASE_TOPIC = os.getenv('PUBSUB_NEW_CASE_TOPIC', 'event_new-case')
 
     DB_USERNAME = os.getenv('DB_USERNAME', 'postgres')


### PR DESCRIPTION
# Motivation and Context
To comply with [v0.3_RELEASE](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/v0.3_RELEASE/surveyUpdate.schema.json) of the shared events (JSON schema / event dictionary) and to comply with [0.4.0-DRAFT](https://github.com/ONSdigital/ssdc-shared-events/blob/main/event_dictionary/v0.4_RELEASE/surveyUpdate.schema.json) we have to emit `surveyUpdate` events to the `event_survey-update` topic.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Added UI form input sections to allow the users setting up surveys to specify the URL of the sample definition, which should be documented, versioned etc.

Also added input section for metadata.

Then, emitted the event when the survey has been inserted into the database.

# How to test?
Create a survey. Have a look at the `surveyUpdate` event which was emitted.

# Links
Trello: https://trello.com/c/GG73DrrF

# Screenshots (if appropriate):
<img width="1079" alt="Screenshot 2021-10-08 at 15 09 10" src="https://user-images.githubusercontent.com/41681172/136574343-eaad6883-6ccc-4c39-b17c-ff4a70475f12.png">
<img width="622" alt="Screenshot 2021-10-08 at 15 08 32" src="https://user-images.githubusercontent.com/41681172/136574351-e252ce9f-d6ef-40dc-8a4e-26e043c44a5e.png">
<img width="639" alt="Screenshot 2021-10-08 at 15 07 19" src="https://user-images.githubusercontent.com/41681172/136574353-1cbb9378-797e-4c70-b9e1-2ca6ecc2c764.png">
