### PR TITLE
Fix ATs broken by newCase strict sensitive data checking

### DIFF
--- a/acceptance_tests/features/exception_manager.feature
+++ b/acceptance_tests/features/exception_manager.feature
@@ -41,7 +41,13 @@ Feature: Check exception manager is called for every topic and handles them as e
     And each bad msg can be successfully quarantined
 
   Scenario: Bad new case message turns up in exception manager
-    Given the sample file "SIS2_random_20.csv" with validation rules "SIS2_validation_rules.json" is loaded successfully
+    Given the sample file "sis_survey_link.csv" with validation rules "SIS2_validation_rules.json" is loaded successfully
     When an invalid newCase event is put on the topic
     Then a bad message appears in exception manager with exception message containing "Column 'schoolId' value 'schoolidistoolong' validation error: Exceeded max length of 11"
+    And each bad msg can be successfully quarantined
+
+  Scenario: Bad new case message turns up in exception manager
+    Given the sample file "sis_survey_link.csv" with validation rules "SIS2_validation_rules.json" is loaded successfully
+    When an invalid newCase event with extra sensitive data is put on the topic
+    Then a bad message appears in exception manager with exception message containing "Attempt to send sensitive data to RM which was not part of defined sample"
     And each bad msg can be successfully quarantined

--- a/acceptance_tests/features/new_case.feature
+++ b/acceptance_tests/features/new_case.feature
@@ -1,7 +1,7 @@
 Feature: A new case is submitted
 
  Scenario: A new case is submitted
-   Given sample file "sis_survey_link.csv" with sensitive columns [PHONE_NUMBER,CHILD_NAME] is loaded successfully
+   Given sample file "sis_survey_link.csv" with sensitive columns [firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey] is loaded successfully
    When a newCase event is built and submitted
    Then a CASE_UPDATED message is emitted for the new case
    And the event logged against the case is [NEW_CASE]

--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -2,8 +2,8 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
 
   @reset_notify_stub
   Scenario: A SMS message is sent via action rule
-    Given sample file "sis_survey_link.csv" with sensitive columns [PHONE_NUMBER,CHILD_NAME] is loaded successfully
-    And a sms template has been created with template "["__sensitive__.CHILD_NAME","__uac__"]"
+    Given sample file "sis_survey_link.csv" with sensitive columns [firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey] is loaded successfully
+    And a sms template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When a SMS action rule has been created
     Then the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,SMS_FULFILMENT]
-    And notify api was called with SMS template with phone number "07123456789" and Childs name "Huckleberry Finn"
+    And notify api was called with SMS template with phone number "07123456666" and child surname "McChildy"

--- a/acceptance_tests/features/steps/new_case.py
+++ b/acceptance_tests/features/steps/new_case.py
@@ -33,8 +33,6 @@ def build_new_case_and_submit(context):
                     "sample": {
                         "schoolId": "abc123",
                         "schoolName": "Chesterthorps High School",
-                        "consentGivenTest": "true",
-                        "consentGivenSurvey": "true"
                     },
                     "sampleSensitive": {
                         "firstName": "Fred",
@@ -43,11 +41,10 @@ def build_new_case_and_submit(context):
                         "childMiddleNames": "Rose May",
                         "childLastName": "Pinker",
                         "childDob": "2001-12-31",
-                        "additionalInfo": "Class 2A",
-                        "childMobileNumber": "07123456789",
-                        "childEmailAddress": "jo.rose.may.pinker@domain.com",
-                        "parentMobileNumber": "07123456789",
-                        "parentEmailAddress": "fred.bloggs@domain.com"
+                        "mobileNumber": "07123456789",
+                        "emailAddress": "fred.bloggs@domain.com",
+                        "consentGivenTest": "true",
+                        "consentGivenSurvey": "true"
                     }
                 }
             }
@@ -62,8 +59,6 @@ def build_invalid_case_and_submit(context):
     context.message_id = str(uuid.uuid4())
     context.correlation_id = str(uuid.uuid4())
     context.originating_user = "foo.bar@ons.gov.uk"
-
-    # Should fail validation due to the schoolId number being > 11 chars
     message = json.dumps(
         {
             "header": {
@@ -83,8 +78,6 @@ def build_invalid_case_and_submit(context):
                     "sample": {
                         "schoolId": "schoolidistoolong",
                         "schoolName": "Chesterthorps High School",
-                        "consentGivenTest": "true",
-                        "consentGivenSurvey": "true"
                     },
                     "sampleSensitive": {
                         "firstName": "Fred",
@@ -93,11 +86,59 @@ def build_invalid_case_and_submit(context):
                         "childMiddleNames": "Rose May",
                         "childLastName": "Pinker",
                         "childDob": "2001-12-31",
-                        "additionalInfo": "Class 2A",
-                        "childMobileNumber": "07123456789",
-                        "childEmailAddress": "jo.rose.may.pinker@domain.com",
-                        "parentMobileNumber": "07123456789",
-                        "parentEmailAddress": "fred.bloggs@domain.com"
+                        "mobileNumber": "07123456789",
+                        "emailAddress": "fred.bloggs@domain.com",
+                        "consentGivenTest": "true",
+                        "consentGivenSurvey": "true"
+                    }
+                }
+            }
+        }
+    )
+    publish_to_pubsub(message, project=Config.PUBSUB_PROJECT, topic=Config.PUBSUB_NEW_CASE_TOPIC)
+
+    context.message_hashes = [hashlib.sha256(message.encode('utf-8')).hexdigest()]
+    context.sent_messages.append(message)
+
+
+@step("an invalid newCase event with extra sensitive data is put on the topic")
+def build_invalid_case_with_extra_sensitive_data_and_submit(context):
+    context.case_id = str(uuid.uuid4())
+    context.message_id = str(uuid.uuid4())
+    context.correlation_id = str(uuid.uuid4())
+    context.originating_user = "foo.bar@ons.gov.uk"
+    message = json.dumps(
+        {
+            "header": {
+                "version": Config.EVENT_SCHEMA_VERSION,
+                "topic": Config.PUBSUB_NEW_CASE_TOPIC,
+                "source": "cupidatat",
+                "channel": "EQ",
+                "dateTime": "1970-01-01T00:00:00.000Z",
+                "messageId": context.message_id,
+                "correlationId": context.correlation_id,
+                "originatingUser": context.originating_user
+            },
+            "payload": {
+                "newCase": {
+                    "caseId": context.case_id,
+                    "collectionExerciseId": context.collex_id,
+                    "sample": {
+                        "schoolId": "abc123",
+                        "schoolName": "Chesterthorps High School",
+                    },
+                    "sampleSensitive": {
+                        "bankAccountPinNumber": "1234 this is obviously data we wouldn't want to store!!",
+                        "firstName": "Fred",
+                        "lastName": "Bloggs",
+                        "childFirstName": "Jo",
+                        "childMiddleNames": "Rose May",
+                        "childLastName": "Pinker",
+                        "childDob": "2001-12-31",
+                        "mobileNumber": "07123456789",
+                        "emailAddress": "fred.bloggs@domain.com",
+                        "consentGivenTest": "true",
+                        "consentGivenSurvey": "true"
                     }
                 }
             }

--- a/acceptance_tests/features/steps/sms_action_rule.py
+++ b/acceptance_tests/features/steps/sms_action_rule.py
@@ -3,11 +3,13 @@ from acceptance_tests.utilities.notify_helper import check_notify_api_called_wit
 from acceptance_tests.utilities.test_case_helper import test_helper
 
 
-@step('notify api was called with SMS template with phone number "{expected_phone_number}" and Childs name "{'
-      'expected_childs_name}"')
-def check_notify_called_with_correct_phone_number_and_childs_name(context, expected_phone_number, expected_childs_name):
+@step('notify api was called with SMS template with phone number "{expected_phone_number}" and child surname "{'
+      'expected_child_surname}"')
+def check_notify_called_with_correct_phone_number_and_child_surname(context, expected_phone_number,
+                                                                    expected_child_surname):
     received_notify_call = check_notify_api_called_with_correct_notify_template_id(expected_phone_number,
                                                                                    context.notify_template_id)
 
-    test_helper.assertEqual(received_notify_call['personalisation']['__sensitive__.CHILD_NAME'], expected_childs_name,
-                            f"Incorrect Childs name sent to notify, json sent {received_notify_call}")
+    test_helper.assertEqual(received_notify_call['personalisation']['__sensitive__.childLastName'],
+                            expected_child_surname,
+                            f"Incorrect child surname name sent to notify, json sent {received_notify_call}")

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -43,7 +43,7 @@ def setup_sms_action_rule(collex_id, pack_code):
         'triggerDateTime': f'{datetime.utcnow().isoformat()}Z',
         'classifiers': '',
         'collectionExerciseId': collex_id,
-        'phoneNumberColumn': 'PHONE_NUMBER',
+        'phoneNumberColumn': 'mobileNumber',
         'uacMetadata': {"waveOfContact": "1"}
     }
 

--- a/resources/sample_files/sis_survey_link.csv
+++ b/resources/sample_files/sis_survey_link.csv
@@ -1,2 +1,2 @@
-ADDRESS_LINE1,ADDRESS_LINE2,TOWN_NAME,POSTCODE,PHONE_NUMBER,CHILD_NAME
-House 7,Bob Street,Newport,NW16 FNK,07123456789,Huckleberry Finn
+schoolId,schoolName,firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey
+123,The Schooliest School,Arnett,Wibnorth,Dababy,Boya,McChildy,2005-03-04,07123456666,nope@nope.nope,true,true


### PR DESCRIPTION
# Motivation and Context
ATs are broken in the pipeline.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
RM is now strict about any sensitive data it receives: if it hasn't been defined on the survey, we won't accept it.

# How to test?
Run the ATs against `main`... should all pass.

# Links
Trello: https://trello.com/c/89DC0oPU