### PR TITLE
Emit caseUpdate message when we receive updateSampleSensitive message

### DIFF
--- a/acceptance_tests/features/sensitive_data.feature
+++ b/acceptance_tests/features/sensitive_data.feature
@@ -4,4 +4,5 @@ Feature: Sample data in the case is sensitive and must be redacted
     Given sample file "sensitive_data_sample.csv" with sensitive columns [PHONE_NUMBER] is loaded successfully
     When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER to 07898787878
     Then the PHONE_NUMBER in the sensitive data on the case has been updated to 07898787878
+    And a CASE_UPDATED message is emitted for the case
     And the events logged against the case are [NEW_CASE,UPDATE_SAMPLE_SENSITIVE]

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -22,16 +22,17 @@ def sensitive_data_on_case_changed(context, sensitive_column, expected_value):
     'an UPDATE_SAMPLE_SENSITIVE event is received updating the {sensitive_column} to {new_value}')
 def send_update_sample_sensitive(context, sensitive_column, new_value):
     context.correlation_id = str(uuid.uuid4())
+    context.case_id = context.emitted_cases[0]['caseId']
     context.originating_user = add_random_suffix_to_email(context.scenario_name)
     message = _send_update_sample_sensitive_msg(context.correlation_id, context.originating_user,
-                                                context.emitted_cases[0]['caseId'], {sensitive_column: new_value})
+                                                context.case_id, {sensitive_column: new_value})
     context.sent_messages.append(message)
 
 
 @retry(wait=wait_fixed(1), stop=stop_after_delay(30))
 def retry_check_sensitive_data_change(context, sensitive_column, expected_value):
     with open_cursor() as cur:
-        cur.execute("SELECT sample_sensitive FROM casev3.cases WHERE id = %s", (context.emitted_cases[0]['caseId'],))
+        cur.execute("SELECT sample_sensitive FROM casev3.cases WHERE id = %s", (context.case_id,))
         result = cur.fetchone()
 
         test_helper.assertEqual(result[0][sensitive_column], expected_value,


### PR DESCRIPTION
# Motivation and Context
We should emit a `caseUpdate` message when sensitive data is updated, so that other products in SDC know, for example, if a phone number has been added or removed to/from a case.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Emit `caseUpdate` event.

# How to test?
Run the ATs.

# Links
Trello: https://trello.com/c/7tYnlMSW