### PR TITLE
Log context with test helper

### DIFF
--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -1,12 +1,8 @@
-import logging
 import random
 import string
 
-from structlog import wrap_logger
 
 from acceptance_tests.utilities.test_case_helper import test_helper
-
-logger = wrap_logger(logging.getLogger(__name__))
 
 
 def get_unique_user_email():


### PR DESCRIPTION
# Motivation and Context
logger.error  and all logging being ignored in context.
Setting up a test concourse, finding reason is complex/costly - this solution isn't ideal.  But it's for AT info logging, not prod code.

Solution uses what we know works, test_helper.  
This has the added bonus of being much easier to read as it doesn't prefix every line with 50+ chars of ERROR, function path, datetime.


# What has changed
In audit trail helper use test_helper to output desired logging.  


# How to test?
Nobble a test.  I stuck:  test_helper.assertFalse(True) at the bottom of load_sample_file_with_validation_rules_step.
This runs with the SIS2 feature that for me runs 1st.   Then run 'make test' does the logging appear, does it look nice.

# Links
https://trello.com/c/PhFkyBYF/2965-acceptance-test-failure-logging-dumping-out-the-entire-context-not-working-in-concourse-2-day