### PR TITLE
3005 Consume all survey update messages

### DIFF
--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -67,13 +67,6 @@ def get_uac_update_events(expected_number, correlation_id, originating_user):
     return uac_payloads
 
 
-def get_emitted_survey_update():
-    message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
-                                                           expected_msg_count=1)[0]
-
-    return message_received['payload']['surveyUpdate']
-
-
 def get_emitted_collection_exercise_update():
     message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION,
                                                            expected_msg_count=1)[0]

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -105,8 +105,8 @@ def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeou
     return parsed_message_bodies
 
 
-def get_matching_pubsub_messages_acking_others(subscription, message_matcher: Callable[[Mapping], tuple[bool, str]],
-                                               timeout=30):
+def get_matching_pubsub_message_acking_others(subscription, message_matcher: Callable[[Mapping], tuple[bool, str]],
+                                              timeout=30):
     """
     Pull and ack all pubsub messages on the given subscription within the timeout, until a match is found
     message_matcher is a function which takes the parsed message body json and returns a bool for whether it matches

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from typing import Callable, Mapping
 
 from google.api_core.exceptions import DeadlineExceeded
 from google.cloud import pubsub_v1
@@ -102,3 +103,36 @@ def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeou
 
     subscriber.close()
     return parsed_message_bodies
+
+
+def get_matching_pubsub_messages_acking_others(subscription, message_matcher: Callable[[Mapping], tuple[bool, str]],
+                                               timeout=30):
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(Config.PUBSUB_PROJECT, subscription)
+    deadline = time.time() + timeout
+    matched_message = None
+
+    # The PubSub subscriber client does not wait the full duration of its timeout before returning if it finds just
+    # at least one message. To work around this, we loop pulling messages repeatedly within our own timeout to allow
+    # the full time for all the expected messages to be published and pulled
+    while not matched_message and not time.time() > deadline:
+        try:
+            response = subscriber.pull(subscription_path, max_messages=1, timeout=1)
+        except DeadlineExceeded:
+            continue
+        if response.received_messages:
+            received_message = response.received_messages[0]
+            parsed_message = json.loads(received_message.message.data)
+            message_match, failure_description = message_matcher(parsed_message)
+            if message_match:
+                matched_message = parsed_message
+            else:
+                logger.warn(f'Acking non matching message on subscription {subscription_path}, '
+                            f'failed match: {failure_description}')
+            subscriber.acknowledge(subscription_path, [received_message.ack_id])
+
+    if matched_message:
+        return matched_message
+
+    test_helper.fail(f'Expected to pull a matching message using matcher: {message_matcher.__doc__}, on '
+                     f'subscription {subscription_path} but found no matches within the {timeout} second timeout')

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from functools import partial
+from typing import Mapping
 
 import requests
 
-from acceptance_tests.utilities.event_helper import get_emitted_survey_update
+from acceptance_tests.utilities.pubsub_helper import get_matching_pubsub_messages_acking_others
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -24,7 +26,7 @@ def add_survey(sample_validation_rules, sample_has_header_row=True, sample_file_
 
     survey_id = response.json()
 
-    survey_update_event = get_emitted_survey_update()
+    survey_update_event = get_emitted_survey_update(survey_name)
     test_helper.assertEqual(survey_update_event['name'], survey_name,
                             'Unexpected survey name')
     test_helper.assertEqual(survey_update_event['sampleDefinitionUrl'], "http://foo.bar",
@@ -33,3 +35,19 @@ def add_survey(sample_validation_rules, sample_has_header_row=True, sample_file_
                             'Unexpected metadata')
 
     return survey_id
+
+
+def get_emitted_survey_update(expected_survey_name):
+    message_received = get_matching_pubsub_messages_acking_others(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
+                                                                  partial(match_message_survey_name,
+                                                                          expected_survey_name=expected_survey_name))
+
+    return message_received['payload']['surveyUpdate']
+
+
+def match_message_survey_name(message: Mapping, expected_survey_name=None) -> (bool, str):
+    """Survey update event survey name matches expected"""
+    if message['payload']['surveyUpdate']['name'] == expected_survey_name:
+        return True, ''
+    return False, f'Actual survey name "{message["payload"]["surveyUpdate"]["name"]}" ' \
+                  f'does not match expected "{expected_survey_name}"'

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -4,7 +4,7 @@ from typing import Mapping
 
 import requests
 
-from acceptance_tests.utilities.pubsub_helper import get_matching_pubsub_messages_acking_others
+from acceptance_tests.utilities.pubsub_helper import get_matching_pubsub_message_acking_others
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -41,8 +41,8 @@ def get_emitted_survey_update(expected_survey_name):
     # Build the matcher with the current expected survey name
     survey_name_matcher = partial(_survey_name_message_matcher, expected_survey_name=expected_survey_name)
 
-    message_received = get_matching_pubsub_messages_acking_others(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
-                                                                  survey_name_matcher)
+    message_received = get_matching_pubsub_message_acking_others(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
+                                                                 survey_name_matcher)
 
     return message_received['payload']['surveyUpdate']
 

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -38,15 +38,16 @@ def add_survey(sample_validation_rules, sample_has_header_row=True, sample_file_
 
 
 def get_emitted_survey_update(expected_survey_name):
+    # Build the matcher with the current expected survey name
+    survey_name_matcher = partial(_survey_name_message_matcher, expected_survey_name=expected_survey_name)
+
     message_received = get_matching_pubsub_messages_acking_others(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
-                                                                  partial(match_message_survey_name,
-                                                                          expected_survey_name=expected_survey_name))
+                                                                  survey_name_matcher)
 
     return message_received['payload']['surveyUpdate']
 
 
-def match_message_survey_name(message: Mapping, expected_survey_name=None) -> (bool, str):
-    """Survey update event survey name matches expected"""
+def _survey_name_message_matcher(message: Mapping, expected_survey_name=None) -> (bool, str):
     if message['payload']['surveyUpdate']['name'] == expected_survey_name:
         return True, ''
     return False, f'Actual survey name "{message["payload"]["surveyUpdate"]["name"]}" ' \


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

Pubsub message acknowledgements are "best effort" which means that occasionally a successfully consumed message will be redelivered later. It seems to happen much more frequently on the first message processed after a period of no activity. This has been causing intermittent CI test failures on survey update messages, since this is the first thing published/consumed in a test run. To work around this behaviour of Pubsub, we will try a different strategy for verifying these messages are emitted, where we will consume and ack any messages found on the subscription (within a timeout), but only continue with the scenario once a message with the correct survey name is found. 

I've tried to code this pattern in a reusable way, so it can easily be applied to other event types if required. The new Pubsub helper takes a matcher function which will only return a match but consume and ack any message which does not match. 

# What has changed
- Create and use new Pubsub pull helper with matcher

# How to test?
Check the ATs still pass. You can verify the code now handles stray extra events by running a scenario in debug and pausing the code just before it adds a survey, then create some extra surveys manually, so there are extra messages on the subscription when it checks. The scenario should now still pass in this case.

# Links
https://trello.com/c/HeMLqTuL/3005-at-flakiness-pull-all-surveyupdate-messages-and-throw-away-any-we-dont-want-3