### PR TITLE
Check surveyUpdate when allowing file export or SMS template on survey

### DIFF
--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -129,7 +129,9 @@ def create_export_file_template(context, template):
     body = {
         'packCode': context.pack_code,
         'exportFileDestination': 'SUPPLIER_A',
-        'template': json.loads(template)
+        'template': json.loads(template),
+        'description': "Test description",
+        'metadata': {"foo": "bar"}
     }
 
     response = requests.post(url, json=body)

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -74,6 +74,13 @@ def get_emitted_survey_update():
     return message_received['payload']['surveyUpdate']
 
 
+def get_exactly_one_emitted_survey_update():
+    message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
+                                                           expected_msg_count=1)[0]
+
+    return message_received['payload']['surveyUpdate']
+
+
 def get_emitted_collection_exercise_update():
     message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION,
                                                            expected_msg_count=1)[0]

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,5 +1,6 @@
 import json
 import time
+import logging
 from typing import Callable, Mapping
 
 from google.api_core.exceptions import DeadlineExceeded
@@ -7,6 +8,9 @@ from google.cloud import pubsub_v1
 
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
+
+from structlog import wrap_logger
+logger = wrap_logger(logging.getLogger(__name__))
 
 
 def publish_to_pubsub(message, project, topic, **kwargs):


### PR DESCRIPTION
# Motivation and Context
A `surveyUpdate` event will be emitted when an Export File or SMS template is allowed on a survey. We should check that it's been emitted correctly.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Check the `surveyUpdate` event contains the details of any allowed fulfilments.

# How to test?
Run the ATs.

# Links
Trello: https://trello.com/c/TvoPKktF