### PR TITLE
test sensitive data on case update events

### DIFF
--- a/acceptance_tests/features/bulk_file_processing.feature
+++ b/acceptance_tests/features/bulk_file_processing.feature
@@ -18,5 +18,4 @@ Feature: bulk file processed
   Scenario: After a sample is loaded the sensitive data can be updated
     Given the sample file "SIS2_random_20.csv" with validation rules "SIS2_validation_rules.json" is loaded successfully
     When a bulk sensitive update file is created for every case created and uploaded
-    Then a CASE_UPDATE message is emitted for each case
-    And in the database the sensitive data has been updated as expected
+    Then in the database the sensitive data has been updated as expected and is emitted redacted

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -149,7 +149,7 @@ def get_bulk_data_row_from_case_id_or_fail(bulk_data, case_id):
 
 @step("a CASE_UPDATE message is emitted for each case with sensitive data redacted")
 def case_update_message_emited_for_every_case_with_sensitive_data_redacted(context):
-    emitted_updated_cases = get_emitted_cases(len(context.emitted_cases))
+    emitted_updated_cases = get_emitted_cases(len(context.bulk_sensitive_update))
 
     for emitted_case in emitted_updated_cases:
         bulk_update_for_case = get_bulk_data_row_from_case_id_or_fail(context.bulk_sensitive_update,

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -88,7 +88,7 @@ def _check_uacs_updated_match_cases(uac_update_events, cases):
 
 @step("a CASE_UPDATE message is emitted for each bulk updated case with expected refusal type")
 def case_emitted_with_field_set_to_value(context):
-    emitted_updated_cases = get_emitted_cases(len(context.bulk_refusal))
+    emitted_updated_cases = get_emitted_cases(len(context.bulk_refusals))
 
     for emitted_case in emitted_updated_cases:
         test_helper.assertIn(emitted_case['caseId'], context.bulk_refusals.keys(),

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -148,7 +148,7 @@ def get_bulk_data_row_from_case_id_or_fail(bulk_data, case_id):
 
 
 @step("a CASE_UPDATE message is emitted for each case with sensitive data redacted")
-def case_update_message_emiited_for_every_case(context):
+def case_update_message_emited_for_every_case_with_sensitive_data_redacted(context):
     emitted_updated_cases = get_emitted_cases(len(context.emitted_cases))
 
     for emitted_case in emitted_updated_cases:

--- a/acceptance_tests/features/steps/sample_loading.py
+++ b/acceptance_tests/features/steps/sample_loading.py
@@ -21,7 +21,7 @@ def get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns=[]
     for emitted_case in emitted_cases:
         matched_row = None
         for sample_row in sample_rows:
-            if get_none_sensitive_row_data(sample_row, sensitive_columns) == emitted_case['sample']:
+            if get_sample_only_data(sample_row, sensitive_columns) == emitted_case['sample']:
 
                 if get_expected_emitted_sensitive_data(sample_row, sensitive_columns) \
                         == emitted_case['sampleSensitive']:
@@ -37,7 +37,7 @@ def get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns=[]
     return emitted_cases
 
 
-def get_none_sensitive_row_data(sample_row, sensitive_columns):
+def get_sample_only_data(sample_row, sensitive_columns):
     return {k: v for k, v in sample_row.items() if k not in sensitive_columns}
 
 

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -115,7 +115,7 @@ def create_and_upload_sensitive_update_file(context):
 
 
 @step("in the database the sensitive data has been updated as expected and is emitted redacted")
-def sensitive_data_updated_in_database_as_expected(context):
+def sensitive_data_updated_in_database_as_expected_and_is_emitted(context):
     emitted_updated_cases = get_emitted_cases(len(context.bulk_sensitive_update))
 
     for expected_update in context.bulk_sensitive_update:

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -149,4 +149,4 @@ def get_emitted_case_by_id(case_id_to_match, all_emitted_update_cases):
             return updated_case
 
     test_helper.fail(f"Couldn't find case update emitted with case ID: {case_id_to_match}"
-                     f"Full emitted_case_update_events list: {all_emitted_update_cases}")
+                     f" Full emitted_case_update_events list: {all_emitted_update_cases}")

--- a/acceptance_tests/features/update_sample_sensitive.feature
+++ b/acceptance_tests/features/update_sample_sensitive.feature
@@ -4,5 +4,5 @@ Feature: Sensitive sample data in the case can be updated
     Given sample file "sensitive_data_sample.csv" with sensitive columns [PHONE_NUMBER] is loaded successfully
     When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER to 07898787878
     Then the PHONE_NUMBER in the sensitive data on the case has been updated to 07898787878
-    And a CASE_UPDATED message is emitted for the case
+    And a CASE_UPDATED message is emitted for the case with correct sensitive data
     And the events logged against the case are [NEW_CASE,UPDATE_SAMPLE_SENSITIVE]


### PR DESCRIPTION
# Motivation and Context
Case emitted events should now emit sensitive data too, but REDACTED.
Test that this happens

# What has changed
Tests for it

# How to test?
With case proc from attached ticket

# Links
https://trello.com/b/yarvSxGu/social-generic-response-management

# Screenshots (if appropriate):