### PR TITLE
3062 Consume the UAC update sent after email action rule

### DIFF
--- a/acceptance_tests/features/email_action_rule.feature
+++ b/acceptance_tests/features/email_action_rule.feature
@@ -5,5 +5,6 @@ Feature: Check action rule for email feature is able to send email via notify
     Given sample file "sis_survey_link.csv" with sensitive columns [firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey] is loaded successfully
     And an email template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When an email action rule has been created
-    Then the events logged against the case are [NEW_CASE,ACTION_RULE_EMAIL_REQUEST,EMAIL_FULFILMENT]
+    Then 1 UAC_UPDATE messages are emitted with active set to true
+    And the events logged against the case are [NEW_CASE,ACTION_RULE_EMAIL_REQUEST,EMAIL_FULFILMENT]
     And notify api was called with email template with email address "nope@nope.nope" and child surname "McChildy"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
The email action rule causes a UAC update message to be sent which should then be consumed.

# What has changed
- Consume email action rule UAC

# How to test?
Run locally.

# Links
https://trello.com/c/ne3EXfY7/3062-at-scenario-an-email-is-sent-via-action-rule-not-consuming-uacupdate-event-that-it-creates