### PR TITLE
Consume UAC UPDATE in SMS action rule scenario

### DIFF
--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -5,5 +5,6 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
     Given sample file "sis_survey_link.csv" with sensitive columns [firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey] is loaded successfully
     And a sms template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When a SMS action rule has been created
-    Then the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,SMS_FULFILMENT]
+    Then 1 UAC_UPDATE messages are emitted with active set to true
+    And the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,SMS_FULFILMENT]
     And notify api was called with SMS template with phone number "07123456666" and child surname "McChildy"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
The scenario was generating a UAC UPDATE event it was not consuming.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Consume and check UAC UPDATE event in SMS action rule scenario

# How to test?
Run the tests locally

# Links
 https://trello.com/c/OdMJ6ywi/3094-sms-action-rule-at-scenario-doesnt-consume-the-uac-update-it-generates