### PR TITLE
Migrate to shared events version 0.5.0 release

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 class Config:
-    EVENT_SCHEMA_VERSION = "v0.3_RELEASE"
+    EVENT_SCHEMA_VERSION = "0.5.0"
 
     PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', 'shared-project')
     PUBSUB_RECEIPT_TOPIC = os.getenv('PUBSUB_RECEIPT_TOPIC', 'event_receipt')


### PR DESCRIPTION
# Motivation and Context
We have released `0.5.0` of the [shared events](https://github.com/ONSdigital/ssdc-shared-events) so it's time to bring our microservices in line with that spec.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Changed all the microservices to publish `0.5.0` as the event version in the headers, and do a few other tweaks to meet the specification.

Also, allow some more versions to be sent to us for present and future needs.

# How to test?
Zero regression - ATs should pass.

# Links
Trello: https://trello.com/c/9uTTLrLW