### PR TITLE
Collection Instrument Rules

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -38,30 +38,31 @@ def step_to_do_a_thing(context):
 Every context attribute used by the tests should be described here.
 Must also be added to the function: log_out_user_context_values in audit_trail_helper.py
 
-| Attribute                    | Description                                                                     |
-| -------------------------    | ------------------------------------------------------------------------------- |
-| test_start_local_datetime    | Stores the local time at the beginning of each scenario in an environment hook  |
-| survey_id                    | Stores the ID of the survey generated and or used by the scenario               |
-| collex_id                    | Stores the ID of the collection exercise generated and or used by the scenario  |
-| emitted_cases                | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events               |
-| emitted_uacs                 | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                 |
-| pack_code                    | Stores the pack code used for fulfilments or action rules                       |
-| template                     | Stores the column template used for fulfilments or action rules                 |
-| telephone_capture_request    | Stores the UAC and QID returned by a telephone capture API call                 |
-| notify_template_id           | Stores the ID of the sms template used for the notify service                   |
-| sms_fulfilment_response_json | Stores the response JSON from a `POST` to the Notify API                        |
-| phone_number                 | Stores the phone number needed to check the notify api                          |
-| email                        | Stores the email address needed to check the notify api                         |
-| message_hashes               | Stores the hash of sent messages, for testing exception management              |
-| correlation_id               | Stores the ID which connects all related events together                        |
-| originating_user             | Stores the email of the ONS employee who originally initiated a business event  |
-| sent_messages                | Stores every scenario sent message for debugging errors                         |
-| scenario_name                | Stores the scenario name and uses it for unique originating users in messages   |
-| case_id                      | Stores the case_id of a case used in the scenario                               |
-| bulk_refusals                | Stores created bulk refusal cases we expect to see messages for                 |
-| bulk_invalids                | Stores the create bulk invalid cases we expect to see messages for              |
-| bulk_sample_update           | Stores the create bulk sample update cases we expect to see messages for        |
-| bulk_sensitive_update        | Stores the bulk sensitive update cases we expect to see messages for            |
+| Attribute                          | Description                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| test_start_local_datetime          | Stores the local time at the beginning of each scenario in an environment hook  |
+| survey_id                          | Stores the ID of the survey generated and or used by the scenario               |
+| collex_id                          | Stores the ID of the collection exercise generated and or used by the scenario  |
+| emitted_cases                      | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events               |
+| emitted_uacs                       | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                 |
+| pack_code                          | Stores the pack code used for fulfilments or action rules                       |
+| template                           | Stores the column template used for fulfilments or action rules                 |
+| telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                 |
+| notify_template_id                 | Stores the ID of the sms template used for the notify service                   |
+| sms_fulfilment_response_json       | Stores the response JSON from a `POST` to the Notify API                        |
+| phone_number                       | Stores the phone number needed to check the notify api                          |
+| email                              | Stores the email address needed to check the notify api                         |
+| message_hashes                     | Stores the hash of sent messages, for testing exception management              |
+| correlation_id                     | Stores the ID which connects all related events together                        |
+| originating_user                   | Stores the email of the ONS employee who originally initiated a business event  |
+| sent_messages                      | Stores every scenario sent message for debugging errors                         |
+| scenario_name                      | Stores the scenario name and uses it for unique originating users in messages   |
+| case_id                            | Stores the case_id of a case used in the scenario                               |
+| bulk_refusals                      | Stores created bulk refusal cases we expect to see messages for                 |
+| bulk_invalids                      | Stores the create bulk invalid cases we expect to see messages for              |
+| bulk_sample_update                 | Stores the create bulk sample update cases we expect to see messages for        |
+| bulk_sensitive_update              | Stores the bulk sensitive update cases we expect to see messages for            |
+| expected_collection_instrument_url | Stores the collection instrument URL expected on emitted `UAC_UPDATE` events    |
 
 ### Sharing Code Between Steps
 

--- a/acceptance_tests/features/collection_instument.feature
+++ b/acceptance_tests/features/collection_instument.feature
@@ -1,0 +1,15 @@
+
+Feature: choose collection instruments for cases
+
+  Scenario: A selection rule chooses the correct collection instrument based on case
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex case CI selection rules
+    And an export file template has been created with template "["__uac__"]"
+    And an export file action rule has been created
+    And UAC_UPDATE messages are emitted with active set to true
+
+  Scenario: A selection rule chooses the correct collection instrument based on UAC metadata and case
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex UAC CI selection rules
+    And a sms template has been created with template "["__uac__", "__qid__"]"
+    And fulfilments are authorised on sms template
+    When a request has been made for a replacement UAC by SMS from phone number "07123456789"
+    Then UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -32,7 +32,9 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
                                                  context.originating_user)
     _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
 
-    _check_new_uacs_are_as_expected(context.emitted_uacs, active)
+    _check_new_uacs_are_as_expected(emitted_uacs=context.emitted_uacs, active=active,
+                                    field_to_test='collectionInstrumentUrl',
+                                    expected_value=context.expected_collection_instrument_url)
 
 
 @step(

--- a/acceptance_tests/features/steps/sample_loading.py
+++ b/acceptance_tests/features/steps/sample_loading.py
@@ -65,7 +65,15 @@ def load_bom_sample_file_step(context, sample_file_name):
         sample_rows[index]['TLA'] = sample_rows[index].pop('\ufeffTLA')
 
     context.survey_id = add_survey(sample_validation_rules)
-    context.collex_id = add_collex(context.survey_id)
+    context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
@@ -78,7 +86,75 @@ def load_sample_file_step(context, sample_file_name):
     sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
 
     context.survey_id = add_survey(sample_validation_rules)
-    context.collex_id = add_collex(context.survey_id)
+
+    context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+
+    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+
+
+@step('sample file "{sample_file_name}" is loaded successfully with complex case CI selection rules')
+def load_sample_file_with_complex_case_ci_rules_step(context, sample_file_name):
+    sample_file_path = SAMPLE_FILES_PATH.joinpath(sample_file_name)
+    sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
+
+    context.survey_id = add_survey(sample_validation_rules)
+
+    context.expected_collection_instrument_url = "http://test-eq.com/complex-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 100,
+            "spelExpression": "caze.sample['POSTCODE'] == 'NW16 FNK'",
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        },
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": "this URL should not be chosen. If it is, the test is a failure"
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+
+    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+
+
+@step('sample file "{sample_file_name}" is loaded successfully with complex UAC CI selection rules')
+def load_sample_file_with_complex_uac_ci_rules_step(context, sample_file_name):
+    sample_file_path = SAMPLE_FILES_PATH.joinpath(sample_file_name)
+    sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
+
+    context.survey_id = add_survey(sample_validation_rules)
+
+    context.expected_collection_instrument_url = "http://test-eq.com/super-complex-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 200,
+            "spelExpression": "caze.sample['POSTCODE'] == 'NW16 FNK' and uacMetadata['waveOfContact'] == '1'",
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        },
+        {
+            "priority": 100,
+            "spelExpression": "caze.sample['POSTCODE'] == 'NW16 FNK'",
+            "collectionInstrumentUrl": "this is a lower priority less specific rule that we don't want"
+        },
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": "this URL should not be chosen. If it is, the test is a failure"
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
@@ -97,7 +173,15 @@ def load_sample_file_with_validation_rules_step(context, sample_file_name, valid
     sensitive_columns = get_sample_sensitive_columns(sample_validation_rules)
 
     context.survey_id = add_survey(sample_validation_rules)
-    context.collex_id = add_collex(context.survey_id)
+    context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
@@ -148,7 +232,15 @@ def load_business_sample_file_step(context):
     sample_rows, validation_rules = get_business_sample_columns_and_validation_rules(sample_file_path)
 
     context.survey_id = add_survey(validation_rules, False, ':')
-    context.collex_id = add_collex(context.survey_id)
+    context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
@@ -163,7 +255,15 @@ def load_sample_file_step_for_sensitive_data_multi_column(context, sample_file_n
                                                                                               sensitive_columns)
 
     context.survey_id = add_survey(sample_validation_rules)
-    context.collex_id = add_collex(context.survey_id)
+    context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
+    collection_instrument_selection_rules = [
+        {
+            "priority": 0,
+            "spelExpression": None,
+            "collectionInstrumentUrl": context.expected_collection_instrument_url
+        }
+    ]
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -7,7 +7,7 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def add_collex(survey_id):
+def add_collex(survey_id, collection_instrument_selection_rules):
     collex_name = 'test collex ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
     start_date = datetime.utcnow()
     end_date = start_date + timedelta(days=2)
@@ -19,13 +19,7 @@ def add_collex(survey_id):
             'startDate': f'{start_date.isoformat()}Z',
             'endDate': f'{end_date.isoformat()}Z',
             'metadata': {'test': 'passed'},
-            'collectionInstrumentSelectionRules': [
-                {
-                    "priority": 0,
-                    "spelExpression": None,
-                    "collectionInstrumentUrl": "http://test-eq.com/test-schema"
-                }
-            ]
+            'collectionInstrumentSelectionRules': collection_instrument_selection_rules
             }
     response = requests.post(url, json=body)
     response.raise_for_status()

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -18,7 +18,14 @@ def add_collex(survey_id):
             'reference': "MVP012021",
             'startDate': f'{start_date.isoformat()}Z',
             'endDate': f'{end_date.isoformat()}Z',
-            'metadata': {'test': 'passed'}
+            'metadata': {'test': 'passed'},
+            'collectionInstrumentSelectionRules': [
+                {
+                    "priority": 0,
+                    "spelExpression": None,
+                    "collectionInstrumentUrl": "http://test-eq.com/test-schema"
+                }
+            ]
             }
     response = requests.post(url, json=body)
     response.raise_for_status()


### PR DESCRIPTION
# Motivation and Context
Choosing the correct collection instrument (CI) for a respondent needs to be rules-based, because there are myriad known and unknown requirements that the ONS has, regarding which questionnaire the organisation wants a respondent to fill in.
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Allowed a block of rules for choosing a collection instrument to be stored against a collection exercise, and these rules are then used to choose the right CI at the moment when the action rule runs.

This has been performance tested with 10k cases, which took 3 minutes to produce the print file = 55/second... pretty slow. but this was on my local MacBook running with the Pub/Sub emulator, and in debug mode. It should scale horizontally, and besides, we need to know what the performance was before for a like-for-like comparison.

We could try choosing the CI when we load the sample, like RAS-RM does, but that just moves the problem around, and it's far less elegant because the CI is not then changing dynamically as the case moves between waves.

I think it's unavoidable that this is a CPU intensive operation, and we simply need to beef up the amount of CPU we give to the Case Processor to accommodate the demand, for massive surveys. At Census scale we would run 10 or more Case Processors.

# How to test?
Set up a survey, then when setting up a collection exercise use these collection instrument rules (or similar):
```json
[
  {
    "priority": 1000,
    "spelExpression": "caze.sample['POSTCODE'] == 'abc123' and uacMetadata != null and uacMetadata['wave'] == 1",
    "collectionInstrumentUrl": "http://quiteAspecific/survey"
  },
  {
    "priority": 500,
    "spelExpression": "caze.sample['POSTCODE'] == 'xyz999'",
    "collectionInstrumentUrl": "http://slightlyLessSpecific/survey"
  },
  {
    "priority": 0,
    "spelExpression": null,
    "collectionInstrumentUrl": "http://allPurpose/survey"
  }
]
```

Then, set up an action rule which includes a UAC (e.g. `["__uac__"]`).

When the action rule triggers, you should be able to see the CI in the emitted `uacUpdate` events, and in the database.

# Links
Trello: https://trello.com/c/SDRjFfs3