### PR TITLE
Differentiate between fulfilments and action rule sends in event log

### DIFF
--- a/acceptance_tests/features/email_action_rule.feature
+++ b/acceptance_tests/features/email_action_rule.feature
@@ -6,5 +6,5 @@ Feature: Check action rule for email feature is able to send email via notify
     And an email template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When an email action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
-    And the events logged against the case are [NEW_CASE,ACTION_RULE_EMAIL_REQUEST,EMAIL_FULFILMENT]
+    And the events logged against the case are [NEW_CASE,ACTION_RULE_EMAIL_REQUEST,ACTION_RULE_EMAIL_CONFIRMATION]
     And notify api was called with email template with email address "nope@nope.nope" and child surname "McChildy"

--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -6,5 +6,5 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
     And a sms template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When a SMS action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
-    And the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,SMS_FULFILMENT]
+    And the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,ACTION_RULE_SMS_CONFIRMATION]
     And notify api was called with SMS template with phone number "07123456666" and child surname "McChildy"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
Emails and sms from fulfilments and action rules are recorded the same in the event log. We want to be able to differentiate between these.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Event type check updated in tests where emails and sms are sent via action rules.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and make up with all other branches on card.
Run ATs
Check the emails and sms sent using action rules are recorded in the event log with the types ACTION_RULE_SMS_CONFIRMATION/ACTION_RULE_EMAIL_CONFIRMATION.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/icUNfLJQ/3057-can-we-differentiate-between-fulfilment-requests-and-action-rule-sends-in-event-log-for-sms-email-8
# Screenshots (if appropriate):