### PR TITLE
Add scenario for print fulfilment request with personlisation

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -35,34 +35,35 @@ def step_to_do_a_thing(context):
 
 #### Context Index
 
-Every context attribute used by the tests should be described here.
-Must also be added to the function: log_out_user_context_values in audit_trail_helper.py
+Every context attribute used by the tests should be described here. Must also be added to the function:
+log_out_user_context_values in audit_trail_helper.py
 
-| Attribute                          | Description                                                                     |
-| ---------------------------------- | ------------------------------------------------------------------------------- |
-| test_start_utc_datetime            | Stores the UTC time at the beginning of each scenario in an environment hook    |
-| survey_id                          | Stores the ID of the survey generated and or used by the scenario               |
-| collex_id                          | Stores the ID of the collection exercise generated and or used by the scenario  |
-| emitted_cases                      | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events               |
-| emitted_uacs                       | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                 |
-| pack_code                          | Stores the pack code used for fulfilments or action rules                       |
-| template                           | Stores the column template used for fulfilments or action rules                 |
-| telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                 |
-| notify_template_id                 | Stores the ID of the sms template used for the notify service                   |
-| sms_fulfilment_response_json       | Stores the response JSON from a `POST` to the Notify API                        |
-| phone_number                       | Stores the phone number needed to check the notify api                          |
-| email                              | Stores the email address needed to check the notify api                         |
-| message_hashes                     | Stores the hash of sent messages, for testing exception management              |
-| correlation_id                     | Stores the ID which connects all related events together                        |
-| originating_user                   | Stores the email of the ONS employee who originally initiated a business event  |
-| sent_messages                      | Stores every scenario sent message for debugging errors                         |
-| scenario_name                      | Stores the scenario name and uses it for unique originating users in messages   |
-| case_id                            | Stores the case_id of a case used in the scenario                               |
-| bulk_refusals                      | Stores created bulk refusal cases we expect to see messages for                 |
-| bulk_invalids                      | Stores the create bulk invalid cases we expect to see messages for              |
-| bulk_sample_update                 | Stores the create bulk sample update cases we expect to see messages for        |
-| bulk_sensitive_update              | Stores the bulk sensitive update cases we expect to see messages for            |
-| expected_collection_instrument_url | Stores the collection instrument URL expected on emitted `UAC_UPDATE` events    |
+| Attribute                          | Description                                                                    |
+|------------------------------------|--------------------------------------------------------------------------------|
+| test_start_utc_datetime            | Stores the UTC time at the beginning of each scenario in an environment hook   |
+| survey_id                          | Stores the ID of the survey generated and or used by the scenario              |
+| collex_id                          | Stores the ID of the collection exercise generated and or used by the scenario |
+| emitted_cases                      | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events              |
+| emitted_uacs                       | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                |
+| pack_code                          | Stores the pack code used for fulfilments or action rules                      |
+| template                           | Stores the column template used for fulfilments or action rules                |
+| telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                |
+| notify_template_id                 | Stores the ID of the sms template used for the notify service                  |
+| sms_fulfilment_response_json       | Stores the response JSON from a `POST` to the Notify API                       |
+| phone_number                       | Stores the phone number needed to check the notify api                         |
+| email                              | Stores the email address needed to check the notify api                        |
+| message_hashes                     | Stores the hash of sent messages, for testing exception management             |
+| correlation_id                     | Stores the ID which connects all related events together                       |
+| originating_user                   | Stores the email of the ONS employee who originally initiated a business event |
+| sent_messages                      | Stores every scenario sent message for debugging errors                        |
+| scenario_name                      | Stores the scenario name and uses it for unique originating users in messages  |
+| case_id                            | Stores the case_id of a case used in the scenario                              |
+| bulk_refusals                      | Stores created bulk refusal cases we expect to see messages for                |
+| bulk_invalids                      | Stores the create bulk invalid cases we expect to see messages for             |
+| bulk_sample_update                 | Stores the create bulk sample update cases we expect to see messages for       |
+| bulk_sensitive_update              | Stores the bulk sensitive update cases we expect to see messages for           |
+| expected_collection_instrument_url | Stores the collection instrument URL expected on emitted `UAC_UPDATE` events   |
+| fulfilment_personalisation         | Stores the personalisation values from a received fulfilment request event     |
 
 ### Sharing Code Between Steps
 

--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -10,3 +10,14 @@ Feature: Print fulfilments can be requested for a case
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
     And the events logged against the case are [NEW_CASE,EXPORT_FILE,PRINT_FULFILMENT]
+
+  Scenario: A print fulfilment including personalisation is requested for a case
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And an export file template has been created with template "["__request__.name","ADDRESS_LINE1","POSTCODE","__uac__"]"
+    And fulfilments are authorised on the export file template
+    And a print fulfilment with personalisation {"name":"Joe Bloggs"} has been requested
+    And the events logged against the case are [NEW_CASE,PRINT_FULFILMENT]
+    When export file fulfilments are triggered to be exported
+    Then UAC_UPDATE messages are emitted with active set to true
+    And an export file is created with correct rows
+    And the events logged against the case are [NEW_CASE,EXPORT_FILE,PRINT_FULFILMENT]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
We want to enable print fulfilment requests to supply extra personalisation values beyond what is stored on the case.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add scenario for print fulfilment request including personalisation.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the service branches linked on the PR (use the docker dev script for speed) then run this branch of ATs.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/fwLbkDJy/3209-ability-to-include-a-name-on-a-fulfilment-by-post-8