### PR TITLE
3246 Personalisation on SMS and email fulfilments

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -49,7 +49,7 @@ log_out_user_context_values in audit_trail_helper.py
 | template                           | Stores the column template used for fulfilments or action rules                |
 | telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                |
 | notify_template_id                 | Stores the ID of the sms template used for the notify service                  |
-| sms_fulfilment_response_json       | Stores the response JSON from a `POST` to the Notify API                       |
+| fulfilment_response_json           | Stores the response JSON from a `POST` to the Notify API                       |
 | phone_number                       | Stores the phone number needed to check the notify api                         |
 | email                              | Stores the email address needed to check the notify api                        |
 | message_hashes                     | Stores the hash of sent messages, for testing exception management             |

--- a/acceptance_tests/features/email_action_rule.feature
+++ b/acceptance_tests/features/email_action_rule.feature
@@ -6,5 +6,5 @@ Feature: Check action rule for email feature is able to send email via notify
     And an email template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When an email action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
-    And the events logged against the case are [NEW_CASE,ACTION_RULE_EMAIL_REQUEST,ACTION_RULE_EMAIL_CONFIRMATION]
+    And the events logged against the case are ["NEW_CASE","ACTION_RULE_EMAIL_REQUEST","ACTION_RULE_EMAIL_CONFIRMATION"]
     And notify api was called with email template with email address "nope@nope.nope" and child surname "McChildy"

--- a/acceptance_tests/features/email_fulfilment.feature
+++ b/acceptance_tests/features/email_fulfilment.feature
@@ -8,8 +8,8 @@ Feature: Email fulfilment
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the email fulfilment UAC
-    And the events logged against the case are [NEW_CASE,EMAIL_FULFILMENT]
-    And notify api was called with email template
+    And the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
+    And notify api was called with the correct email template and values
 
   @reset_notify_stub
   Scenario: An email fulfilment is requested for a case with no uac/qid
@@ -17,5 +17,14 @@ Feature: Email fulfilment
     And an email template has been created with template "[]"
     And fulfilments are authorised on email template
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
-    Then the events logged against the case are [NEW_CASE,EMAIL_FULFILMENT]
-    And notify api was called with email template
+    Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
+    And notify api was called with the correct email template and values
+
+  @reset_notify_stub
+  Scenario: An email fulfilment is requested including personalisation
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And an email template has been created with template "["__request__.name"]"
+    And fulfilments are authorised on email template
+    When a request has been made for a replacement UAC by email from email address "foo@bar.baz" with personalisation {"name": "Joe Bloggs"}
+    Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
+    And notify api was called with the correct email template and values

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import time
 from datetime import datetime
@@ -18,6 +19,7 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 register_type(boolean=lambda text: strtobool(text))
+register_type(json=lambda text: json.loads(text))
 
 
 def move_fulfilment_triggers_harmlessly_massively_into_the_future():

--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -7,4 +7,4 @@ Feature: Handle EQ launch events
     Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     When an EQ_LAUNCH event is received
     Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
-    And the events logged against the case are [NEW_CASE,EXPORT_FILE,EQ_LAUNCH]
+    And the events logged against the case are ["NEW_CASE","EXPORT_FILE","EQ_LAUNCH"]

--- a/acceptance_tests/features/invalid_case.feature
+++ b/acceptance_tests/features/invalid_case.feature
@@ -4,4 +4,4 @@ Feature: A case can be invalidated with an event
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When an INVALID_CASE event is received
     Then a CASE_UPDATE message is emitted where "invalid" is "True"
-    And the events logged against the case are [NEW_CASE,INVALID_CASE]
+    And the events logged against the case are ["NEW_CASE","INVALID_CASE"]

--- a/acceptance_tests/features/new_case.feature
+++ b/acceptance_tests/features/new_case.feature
@@ -4,4 +4,4 @@ Feature: A new case is submitted
    Given sample file "sis_survey_link.csv" with sensitive columns [firstName,lastName,childFirstName,childMiddleNames,childLastName,childDob,mobileNumber,emailAddress,consentGivenTest,consentGivenSurvey] is loaded successfully
    When a newCase event is built and submitted
    Then a CASE_UPDATED message is emitted for the new case
-   And the event logged against the case is [NEW_CASE]
+   And the event logged against the case is ["NEW_CASE"]

--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -5,19 +5,19 @@ Feature: Print fulfilments can be requested for a case
     And an export file template has been created with template "["ADDRESS_LINE1","POSTCODE","__uac__"]"
     And fulfilments are authorised on the export file template
     And a print fulfilment has been requested
-    And the events logged against the case are [NEW_CASE,PRINT_FULFILMENT]
+    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
-    And the events logged against the case are [NEW_CASE,EXPORT_FILE,PRINT_FULFILMENT]
+    And the events logged against the case are ["NEW_CASE","EXPORT_FILE","PRINT_FULFILMENT"]
 
   Scenario: A print fulfilment including personalisation is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     And an export file template has been created with template "["__request__.name","ADDRESS_LINE1","POSTCODE","__uac__"]"
     And fulfilments are authorised on the export file template
     And a print fulfilment with personalisation {"name":"Joe Bloggs"} has been requested
-    And the events logged against the case are [NEW_CASE,PRINT_FULFILMENT]
+    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
-    And the events logged against the case are [NEW_CASE,EXPORT_FILE,PRINT_FULFILMENT]
+    And the events logged against the case are ["NEW_CASE","EXPORT_FILE","PRINT_FULFILMENT"]

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -7,4 +7,4 @@ Feature: A case can be receipted with an event
     And UAC_UPDATE messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic
     Then UAC_UPDATE message is emitted with active set to false and "receiptReceived" is true
-    And the events logged against the case are [NEW_CASE,EXPORT_FILE,RECEIPT]
+    And the events logged against the case are ["NEW_CASE","EXPORT_FILE","RECEIPT"]

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -4,11 +4,11 @@ Feature: A case can be refused with an event
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When a refusal event is received and erase data is "false"
     Then a CASE_UPDATE message is emitted where "refusalReceived" is "EXTRAORDINARY_REFUSAL"
-    And the events logged against the case are [NEW_CASE,REFUSAL]
+    And the events logged against the case are ["NEW_CASE","REFUSAL"]
 
 
   Scenario: A case is loaded and can be refused and data requested to be erased
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When a refusal event is received and erase data is "true"
     Then a CASE_UPDATE message is emitted where "{"refusalReceived": "EXTRAORDINARY_REFUSAL", "sampleSensitive": null,"invalid":true}" are the updated values
-    And the events logged against the case are [NEW_CASE,REFUSAL,ERASE_DATA]
+    And the events logged against the case are ["NEW_CASE","REFUSAL","ERASE_DATA"]

--- a/acceptance_tests/features/respondent_authenticated.feature
+++ b/acceptance_tests/features/respondent_authenticated.feature
@@ -6,4 +6,4 @@ Feature: Handle respondent authenticated events
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a UAC_AUTHENTICATION event is received
-    Then the events logged against the case are [NEW_CASE,EXPORT_FILE,UAC_AUTHENTICATION]
+    Then the events logged against the case are ["NEW_CASE","EXPORT_FILE","UAC_AUTHENTICATION"]

--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -6,5 +6,5 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
     And a sms template has been created with template "["__sensitive__.childLastName","__uac__"]"
     When a SMS action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
-    And the events logged against the case are [NEW_CASE,ACTION_RULE_SMS_REQUEST,ACTION_RULE_SMS_CONFIRMATION]
+    And the events logged against the case are ["NEW_CASE","ACTION_RULE_SMS_REQUEST","ACTION_RULE_SMS_CONFIRMATION"]
     And notify api was called with SMS template with phone number "07123456666" and child surname "McChildy"

--- a/acceptance_tests/features/sms_fulfilment.feature
+++ b/acceptance_tests/features/sms_fulfilment.feature
@@ -8,8 +8,8 @@ Feature: Sms fulfilment
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the SMS fulfilment UAC
-    And the events logged against the case are [NEW_CASE,SMS_FULFILMENT]
-    And notify api was called with SMS template
+    And the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
+    And notify api was called with the correct SMS template and values
 
   @reset_notify_stub
   Scenario: A SMS fulfilment is requested for a case with no uac/qid
@@ -17,5 +17,14 @@ Feature: Sms fulfilment
     And a sms template has been created with template "[]"
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
-    Then the events logged against the case are [NEW_CASE,SMS_FULFILMENT]
-    And notify api was called with SMS template
+    Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
+    And notify api was called with the correct SMS template and values
+
+  @reset_notify_stub
+  Scenario: A SMS fulfilment is requested including personalisation
+    Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
+    And a sms template has been created with template "["__request__.name"]"
+    And fulfilments are authorised on sms template
+    When a request has been made for a replacement UAC by SMS from phone number "07123456789" with personalisation {"name": "Joe Bloggs"}
+    Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
+    And notify api was called with the correct SMS template and values

--- a/acceptance_tests/features/steps/email_action_rule.py
+++ b/acceptance_tests/features/steps/email_action_rule.py
@@ -1,13 +1,13 @@
 from behave import step
-from acceptance_tests.utilities.notify_helper import check_notify_api_called_with_correct_email_and_notify_template_id
+from acceptance_tests.utilities.notify_helper import check_notify_api_called_with_correct_email_and_template_id
 from acceptance_tests.utilities.test_case_helper import test_helper
 
 
 @step('notify api was called with email template with email address "{expected_email}" and child surname "{'
       'expected_child_surname}"')
 def check_notify_called_with_correct_email_and_child_surname(context, expected_email, expected_child_surname):
-    received_notify_call = check_notify_api_called_with_correct_email_and_notify_template_id(expected_email,
-                                                                                             context.notify_template_id)
+    received_notify_call = check_notify_api_called_with_correct_email_and_template_id(expected_email,
+                                                                                      context.notify_template_id)
 
     test_helper.assertEqual(received_notify_call['personalisation']['__sensitive__.childLastName'],
                             expected_child_surname,

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -63,22 +63,22 @@ def request_replacement_uac_by_email(context, email, personalisation=None):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    context.email_fulfilment_response_json = response.json()
+    context.fulfilment_response_json = response.json()
 
-    check_email_fulfilment_response(context.email_fulfilment_response_json, context.template)
+    check_email_fulfilment_response(context.fulfilment_response_json, context.template)
 
 
 @step("the UAC_UPDATE message matches the email fulfilment UAC")
-def check_uac_message_matches_sms_uac(context):
-    test_helper.assertEqual(context.emitted_uacs[0]['uacHash'], context.email_fulfilment_response_json['uacHash'],
+def check_uac_message_matches_email_uac(context):
+    test_helper.assertEqual(context.emitted_uacs[0]['uacHash'], context.fulfilment_response_json['uacHash'],
                             f"Failed to 1st match uacHash, "
                             f"context.emitted_uacs: {context.emitted_uacs} "
-                            f" context.email_fulfilment_response_json {context.email_fulfilment_response_json}")
+                            f" context.fulfilment_response_json {context.fulfilment_response_json}")
 
-    test_helper.assertEqual(context.emitted_uacs[0]['qid'], context.email_fulfilment_response_json['qid'],
+    test_helper.assertEqual(context.emitted_uacs[0]['qid'], context.fulfilment_response_json['qid'],
                             f"Failed to 1st match qid, "
                             f"context.emitted_uacs: {context.emitted_uacs} "
-                            f"context.email_fulfilment_response_json {context.email_fulfilment_response_json}")
+                            f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
 @step('an email template has been created with template "{template:json}"')

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -1,15 +1,12 @@
-import json
-import random
-import string
 import uuid
 
 import requests
 from behave import step
 
+from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.event_helper import get_exactly_one_emitted_survey_update
-from acceptance_tests.utilities.notify_helper import check_email_fulfilment_response, \
-    check_notify_api_called_with_correct_email_and_notify_template_id
+from acceptance_tests.utilities.notify_helper import check_email_fulfilment_response
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -35,7 +32,9 @@ def authorise_sms_pack_code(context):
 
 
 @step('a request has been made for a replacement UAC by email from email address "{email}"')
-def request_replacement_uac_by_email(context, email):
+@step('a request has been made for a replacement UAC by email from email address "{email}"'
+      ' with personalisation {personalisation}')
+def request_replacement_uac_by_email(context, email, personalisation=None):
     context.email = email
     context.correlation_id = str(uuid.uuid4())
     context.originating_user = get_unique_user_email()
@@ -58,17 +57,15 @@ def request_replacement_uac_by_email(context, email):
         }
     }
 
+    if personalisation:
+        context.fulfilment_personalisation = body['payload']['emailFulfilment']['personalisation'] = personalisation
+
     response = requests.post(url, json=body)
     response.raise_for_status()
 
     context.email_fulfilment_response_json = response.json()
 
     check_email_fulfilment_response(context.email_fulfilment_response_json, context.template)
-
-
-@step("notify api was called with email template")
-def check_notify_api_call(context):
-    check_notify_api_called_with_correct_email_and_notify_template_id(context.email, context.notify_template_id)
 
 
 @step("the UAC_UPDATE message matches the email fulfilment UAC")
@@ -84,21 +81,7 @@ def check_uac_message_matches_sms_uac(context):
                             f"context.email_fulfilment_response_json {context.email_fulfilment_response_json}")
 
 
-@step('an email template has been created with template "{template}"')
+@step('an email template has been created with template "{template:json}"')
 def create_email_template(context, template):
-    # By using a unique random pack_code we have better filter options
-    # We can change/remove this if we get UACS differently or a better solution is found
-    context.pack_code = 'pack_code_email_' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
-    context.notify_template_id = str(uuid.uuid4())
     context.template = template
-    url = f'{Config.SUPPORT_TOOL_API}/emailTemplates'
-    body = {
-        'notifyTemplateId': context.notify_template_id,
-        'template': json.loads(context.template),
-        'packCode': context.pack_code,
-        'description': "Test description",
-        'metadata': {"foo": "bar"}
-    }
-
-    response = requests.post(url, json=body)
-    response.raise_for_status()
+    context.pack_code, context.notify_template_id = template_helper.create_email_template(template)

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -33,7 +33,7 @@ def authorise_sms_pack_code(context):
 
 @step('a request has been made for a replacement UAC by email from email address "{email}"')
 @step('a request has been made for a replacement UAC by email from email address "{email}"'
-      ' with personalisation {personalisation}')
+      ' with personalisation {personalisation:json}')
 def request_replacement_uac_by_email(context, email, personalisation=None):
     context.email = email
     context.correlation_id = str(uuid.uuid4())

--- a/acceptance_tests/features/steps/events_logged.py
+++ b/acceptance_tests/features/steps/events_logged.py
@@ -3,11 +3,7 @@ from behave import step
 from acceptance_tests.utilities.case_api_helper import check_if_event_list_is_exact_match
 
 
-@step("the events logged against the case are {expected_event_list}")
+@step("the events logged against the case are {expected_event_list:json}")
+@step("the event logged against the case is {expected_event_list:json}")
 def check_case_events_logged(context, expected_event_list):
     check_if_event_list_is_exact_match(expected_event_list, context.emitted_cases[0]['caseId'])
-
-
-@step("the event logged against the case is {expected_event}")
-def check_case_event(context, expected_event):
-    check_if_event_list_is_exact_match(expected_event, context.case_id)

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -1,25 +1,22 @@
 import csv
 import hashlib
-import json
-import random
-import string
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
 import pgpy
-import requests
 from behave import step
 from google.cloud import storage
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
 
+from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
 @step("an export file is created with correct rows")
 def check_export_file(context):
-    template = context.template.replace('[', '').replace(']', '').replace('"', '').split(',')
+    template = context.template
     emitted_uacs = context.emitted_uacs if hasattr(context, 'emitted_uacs') else None
     fulfilment_personalisation = context.fulfilment_personalisation if hasattr(context,
                                                                                'fulfilment_personalisation') else None
@@ -42,25 +39,10 @@ def check_export_file(context):
     check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
 
 
-@step('an export file template has been created with template "{template}"')
+@step('an export file template has been created with template "{template:json}"')
 def create_export_file_template(context, template):
     context.template = template
-
-    # By using a unique random pack_code we have better filter options
-    # We can change/remove this if we get UACS differently or a better solution is found
-    context.pack_code = 'pack_code_' + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
-
-    url = f'{Config.SUPPORT_TOOL_API}/exportFileTemplates'
-    body = {
-        'packCode': context.pack_code,
-        'exportFileDestination': 'SUPPLIER_A',
-        'template': json.loads(template),
-        'description': "Test description",
-        'metadata': {"foo": "bar"}
-    }
-
-    response = requests.post(url, json=body)
-    response.raise_for_status()
+    context.pack_code = template_helper.create_export_file_template(template)
 
 
 def _get_uac_matching_case_id(uac_update_events, case_id):

--- a/acceptance_tests/features/steps/notify_api.py
+++ b/acceptance_tests/features/steps/notify_api.py
@@ -13,8 +13,8 @@ def check_sms_notify_api_call(context):
     notify_api_call = check_notify_api_called_with_correct_phone_number_and_template_id(context.phone_number,
                                                                                         context.notify_template_id)
     emitted_uac = context.emitted_uacs[0] if hasattr(context, 'emitted_uacs') else None
-    request_personalisation = (context.fulfilment_personalisation if
-                               hasattr(context, 'fulfilment_request_personalisation') else {})
+    request_personalisation = (context.fulfilment_personalisation
+                               if hasattr(context, 'fulfilment_personalisation') else {})
 
     check_notify_api_call(notify_api_call, context.template, context.emitted_cases[0], emitted_uac,
                           request_personalisation)
@@ -26,8 +26,8 @@ def check_email_notify_api_call(context):
                                                                                  context.notify_template_id)
 
     emitted_uac = context.emitted_uacs[0] if hasattr(context, 'emitted_uacs') else None
-    request_personalisation = (context.fulfilment_personalisation if
-                               hasattr(context, 'fulfilment_request_personalisation') else {})
+    request_personalisation = (context.fulfilment_personalisation
+                               if hasattr(context, 'fulfilment_personalisation') else {})
     check_notify_api_call(notify_api_call, context.template, context.emitted_cases[0], emitted_uac,
                           request_personalisation)
 

--- a/acceptance_tests/features/steps/notify_api.py
+++ b/acceptance_tests/features/steps/notify_api.py
@@ -1,0 +1,52 @@
+import hashlib
+
+from behave import step
+
+from acceptance_tests.utilities.fulfilment_helper import build_expected_fulfilment_personalisation
+from acceptance_tests.utilities.notify_helper import check_notify_api_called_with_correct_email_and_template_id, \
+    check_notify_api_called_with_correct_phone_number_and_template_id
+from acceptance_tests.utilities.test_case_helper import test_helper
+
+
+@step("notify api was called with the correct SMS template and values")
+def check_sms_notify_api_call(context):
+    notify_api_call = check_notify_api_called_with_correct_phone_number_and_template_id(context.phone_number,
+                                                                                        context.notify_template_id)
+    emitted_uac = context.emitted_uacs[0] if hasattr(context, 'emitted_uacs') else None
+    request_personalisation = (context.fulfilment_personalisation if
+                               hasattr(context, 'fulfilment_request_personalisation') else {})
+
+    check_notify_api_call(notify_api_call, context.template, context.emitted_cases[0], emitted_uac,
+                          request_personalisation)
+
+
+@step("notify api was called with the correct email template and values")
+def check_email_notify_api_call(context):
+    notify_api_call = check_notify_api_called_with_correct_email_and_template_id(context.email,
+                                                                                 context.notify_template_id)
+
+    emitted_uac = context.emitted_uacs[0] if hasattr(context, 'emitted_uacs') else None
+    request_personalisation = (context.fulfilment_personalisation if
+                               hasattr(context, 'fulfilment_request_personalisation') else {})
+    check_notify_api_call(notify_api_call, context.template, context.emitted_cases[0], emitted_uac,
+                          request_personalisation)
+
+
+def check_notify_api_call(notify_api_call, template, case, emitted_uac, request_personalisation):
+    uac_hash = emitted_uac['uacHash'] if '__uac__' in template else None
+    qid = emitted_uac['qid'] if '__qid__' in template else None
+
+    expected_personalisation = build_expected_fulfilment_personalisation(template, case,
+                                                                         request_personalisation,
+                                                                         uac_hash=uac_hash,
+                                                                         qid=qid)
+
+    actual_personalisation = notify_api_call.get('personalisation', {}).copy()
+
+    # We only have the uac hash to check, so amend the actual values with the hash
+    if '__uac__' in actual_personalisation.keys():
+        actual_personalisation['__uac_hash__'] = hashlib.sha256(actual_personalisation['__uac__'].encode()).hexdigest()
+        actual_personalisation.pop('__uac__')
+
+    test_helper.assertDictEqual(actual_personalisation, expected_personalisation,
+                                'Actual personalisation in notify API call must match expected')

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -13,7 +13,7 @@ from config import Config
 
 
 @step('a print fulfilment has been requested')
-@step('a print fulfilment with personalisation {personalisation} has been requested')
+@step('a print fulfilment with personalisation {personalisation:json} has been requested')
 def request_print_fulfilment_step(context, personalisation=None):
     context.correlation_id = str(uuid.uuid4())
     context.originating_user = add_random_suffix_to_email(context.scenario_name)
@@ -38,7 +38,7 @@ def request_print_fulfilment_step(context, personalisation=None):
     }
 
     if personalisation:
-        context.fulfilment_personalisation = json.loads(personalisation)
+        context.fulfilment_personalisation = personalisation
         message_dict['payload']['printFulfilment']['personalisation'] = context.fulfilment_personalisation
 
     message = json.dumps(message_dict)

--- a/acceptance_tests/features/steps/sms_action_rule.py
+++ b/acceptance_tests/features/steps/sms_action_rule.py
@@ -1,5 +1,5 @@
 from behave import step
-from acceptance_tests.utilities.notify_helper import check_notify_api_called_with_correct_notify_template_id
+from acceptance_tests.utilities.notify_helper import check_notify_api_called_with_correct_phone_number_and_template_id
 from acceptance_tests.utilities.test_case_helper import test_helper
 
 
@@ -7,8 +7,8 @@ from acceptance_tests.utilities.test_case_helper import test_helper
       'expected_child_surname}"')
 def check_notify_called_with_correct_phone_number_and_child_surname(context, expected_phone_number,
                                                                     expected_child_surname):
-    received_notify_call = check_notify_api_called_with_correct_notify_template_id(expected_phone_number,
-                                                                                   context.notify_template_id)
+    received_notify_call = check_notify_api_called_with_correct_phone_number_and_template_id(expected_phone_number,
+                                                                                             context.notify_template_id)
 
     test_helper.assertEqual(received_notify_call['personalisation']['__sensitive__.childLastName'],
                             expected_child_surname,

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -63,22 +63,22 @@ def request_replacement_uac_by_sms(context, phone_number, personalisation=None):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    context.sms_fulfilment_response_json = response.json()
+    context.fulfilment_response_json = response.json()
 
-    check_sms_fulfilment_response(context.sms_fulfilment_response_json, context.template)
+    check_sms_fulfilment_response(context.fulfilment_response_json, context.template)
 
 
 @step("the UAC_UPDATE message matches the SMS fulfilment UAC")
 def check_uac_message_matches_sms_uac(context):
-    test_helper.assertEqual(context.emitted_uacs[0]['uacHash'], context.sms_fulfilment_response_json['uacHash'],
+    test_helper.assertEqual(context.emitted_uacs[0]['uacHash'], context.fulfilment_response_json['uacHash'],
                             f"Failed to 1st match uacHash, "
                             f"context.emitted_uacs: {context.emitted_uacs} "
-                            f" context.sms_fulfilment_response_json {context.sms_fulfilment_response_json}")
+                            f" context.fulfilment_response_json {context.fulfilment_response_json}")
 
-    test_helper.assertEqual(context.emitted_uacs[0]['qid'], context.sms_fulfilment_response_json['qid'],
+    test_helper.assertEqual(context.emitted_uacs[0]['qid'], context.fulfilment_response_json['qid'],
                             f"Failed to 1st match qid, "
                             f"context.emitted_uacs: {context.emitted_uacs} "
-                            f"context.sms_fulfilment_response_json {context.sms_fulfilment_response_json}")
+                            f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
 @step('a sms template has been created with template "{template:json}"')

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -33,7 +33,7 @@ def authorise_sms_pack_code(context):
 
 @step('a request has been made for a replacement UAC by SMS from phone number "{phone_number}"')
 @step('a request has been made for a replacement UAC by SMS from phone number "{phone_number}"'
-      ' with personalisation {personalisation}')
+      ' with personalisation {personalisation:json}')
 def request_replacement_uac_by_sms(context, phone_number, personalisation=None):
     context.phone_number = phone_number
     context.correlation_id = str(uuid.uuid4())

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -4,4 +4,4 @@ Feature: Telephone capture
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     When there is a request for telephone capture of a case
     Then a UAC and QID with questionnaire type "01" type are generated and returned
-    And the events logged against the case are [NEW_CASE,TELEPHONE_CAPTURE]
+    And the events logged against the case are ["NEW_CASE","TELEPHONE_CAPTURE"]

--- a/acceptance_tests/features/update_sample.feature
+++ b/acceptance_tests/features/update_sample.feature
@@ -5,4 +5,4 @@ Feature: Sample data in the case can be updated
     When an UPDATE_SAMPLE event is received updating the ADDRESS_LINE1 to Test Street
     Then the ADDRESS_LINE1 in the data on the case has been updated to Test Street
     And a CASE_UPDATED message is emitted for the case
-    And the events logged against the case are [NEW_CASE,UPDATE_SAMPLE]
+    And the events logged against the case are ["NEW_CASE","UPDATE_SAMPLE"]

--- a/acceptance_tests/features/update_sample_sensitive.feature
+++ b/acceptance_tests/features/update_sample_sensitive.feature
@@ -5,4 +5,4 @@ Feature: Sensitive sample data in the case can be updated
     When an UPDATE_SAMPLE_SENSITIVE event is received updating the PHONE_NUMBER to 07898787878
     Then the PHONE_NUMBER in the sensitive data on the case has been updated to 07898787878
     And a CASE_UPDATED message is emitted for the case with correct sensitive data
-    And the events logged against the case are [NEW_CASE,UPDATE_SAMPLE_SENSITIVE]
+    And the events logged against the case are ["NEW_CASE","UPDATE_SAMPLE_SENSITIVE"]

--- a/acceptance_tests/utilities/case_api_helper.py
+++ b/acceptance_tests/utilities/case_api_helper.py
@@ -13,9 +13,8 @@ def get_logged_events_for_case_by_id(case_id):
 
 
 @retry(wait=wait_fixed(1), stop=stop_after_delay(30))
-def check_if_event_list_is_exact_match(event_type_list, case_id):
+def check_if_event_list_is_exact_match(expected_logged_event_types, case_id):
     actual_logged_events = get_logged_events_for_case_by_id(case_id)
-    expected_logged_event_types = event_type_list.replace('[', '').replace(']', '').split(',')
     actual_logged_event_types = [event['eventType'] for event in actual_logged_events]
 
     test_helper.assertCountEqual(expected_logged_event_types, actual_logged_event_types,

--- a/acceptance_tests/utilities/fulfilment_helper.py
+++ b/acceptance_tests/utilities/fulfilment_helper.py
@@ -23,7 +23,8 @@ def build_expected_fulfilment_personalisation(template: Iterable[str], case, req
                 expected_personalisation[template_item] = request_value
 
         elif template_item.startswith('__sensitive__.'):
-            expected_personalisation[template_item] = case['sampleSensitive'][template_item[len('__sensitive__.'):]]
+            expected_personalisation[template_item] = case['sampleSensitive'][
+                template_item[len('__sensitive__.'):]]
 
         else:
             expected_personalisation[template_item] = case['sample'][template_item]

--- a/acceptance_tests/utilities/fulfilment_helper.py
+++ b/acceptance_tests/utilities/fulfilment_helper.py
@@ -1,0 +1,31 @@
+from typing import Iterable
+
+from acceptance_tests.utilities.test_case_helper import test_helper
+
+
+def build_expected_fulfilment_personalisation(template: Iterable[str], case, request_personalisation={}, uac_hash=None,
+                                              qid=None):
+    expected_personalisation = {}
+    for template_item in template:
+        if template_item == '__uac__':
+            # The actual personalisation values with have the original UAC, but the test has access to the hash
+            test_helper.assertIsNotNone(uac_hash, 'Fulfilment template includes a UAC but one was not supplied'
+                                                  ' to build expected personalisation')
+            expected_personalisation['__uac_hash__'] = uac_hash
+
+        elif template_item == '__qid__':
+            test_helper.assertIsNotNone(qid, 'Fulfilment template includes a QID but one was not supplied'
+                                             ' to build expected personalisation')
+            expected_personalisation[template_item] = qid
+
+        elif template_item.startswith('__request__.'):
+            if request_value := request_personalisation.get(template_item[len('__request__.'):]):
+                expected_personalisation[template_item] = request_value
+
+        elif template_item.startswith('__sensitive__.'):
+            expected_personalisation[template_item] = case['sampleSensitive'][template_item[len('__sensitive__.'):]]
+
+        else:
+            expected_personalisation[template_item] = case['sample'][template_item]
+
+    return expected_personalisation

--- a/acceptance_tests/utilities/notify_helper.py
+++ b/acceptance_tests/utilities/notify_helper.py
@@ -1,5 +1,3 @@
-import json
-
 import requests
 from tenacity import retry, stop_after_delay, wait_fixed
 
@@ -9,7 +7,7 @@ from config import Config
 
 def check_sms_fulfilment_response(sms_fulfilment_response, template):
     expect_uac_hash_and_qid_in_response = any(
-        template_item in json.loads(template) for template_item in ['__qid__', '__uac__'])
+        template_item in template for template_item in ['__qid__', '__uac__'])
 
     if expect_uac_hash_and_qid_in_response:
         test_helper.assertTrue(sms_fulfilment_response['uacHash'],
@@ -23,7 +21,7 @@ def check_sms_fulfilment_response(sms_fulfilment_response, template):
 
 def check_email_fulfilment_response(email_fulfilment_response, template):
     expect_uac_hash_and_qid_in_response = any(
-        template_item in json.loads(template) for template_item in ['__qid__', '__uac__'])
+        template_item in template for template_item in ['__qid__', '__uac__'])
 
     if expect_uac_hash_and_qid_in_response:
         test_helper.assertTrue(email_fulfilment_response['uacHash'],
@@ -36,7 +34,7 @@ def check_email_fulfilment_response(email_fulfilment_response, template):
 
 
 @retry(wait=wait_fixed(1), stop=stop_after_delay(30))
-def check_notify_api_called_with_correct_notify_template_id(phone_number, notify_template_id):
+def check_notify_api_called_with_correct_phone_number_and_template_id(phone_number, notify_template_id):
     response = requests.get(f'{Config.NOTIFY_STUB_SERVICE}/log/sms')
     test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()
@@ -50,7 +48,7 @@ def check_notify_api_called_with_correct_notify_template_id(phone_number, notify
 
 
 @retry(wait=wait_fixed(1), stop=stop_after_delay(30))
-def check_notify_api_called_with_correct_email_and_notify_template_id(email, notify_template_id):
+def check_notify_api_called_with_correct_email_and_template_id(email, notify_template_id):
     response = requests.get(f'{Config.NOTIFY_STUB_SERVICE}/log/email')
     test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -1,0 +1,52 @@
+import random
+import string
+import uuid
+
+import requests
+
+from config import Config
+
+
+def create_template(create_url, pack_code, template, notify_template_id=None, export_file_destination=None):
+    body = {
+        'template': template,
+        'packCode': pack_code,
+        'description': "Test description",
+        'metadata': {"foo": "bar"}
+    }
+    if notify_template_id:
+        body['notifyTemplateId'] = notify_template_id
+
+    if export_file_destination:
+        body['exportFileDestination'] = export_file_destination
+    response = requests.post(create_url, json=body)
+    response.raise_for_status()
+
+
+def create_export_file_template(template, export_file_destination='SUPPLIER_A'):
+    pack_code = generate_pack_code('PRINT_')
+    url = f'{Config.SUPPORT_TOOL_API}/exportFileTemplates'
+    create_template(url, pack_code, template, export_file_destination=export_file_destination)
+    return pack_code
+
+
+def create_sms_template(template):
+    pack_code = generate_pack_code('SMS_')
+    notify_template_id = str(uuid.uuid4())
+    url = f'{Config.SUPPORT_TOOL_API}/smsTemplates'
+    create_template(url, pack_code, template, notify_template_id=notify_template_id)
+    return pack_code, notify_template_id
+
+
+def create_email_template(template):
+    pack_code = generate_pack_code('EMAIL_')
+    notify_template_id = str(uuid.uuid4())
+    url = f'{Config.SUPPORT_TOOL_API}/emailTemplates'
+    create_template(url, pack_code, template, notify_template_id=notify_template_id)
+    return pack_code, notify_template_id
+
+
+def generate_pack_code(pack_code_prefix):
+    # By using a unique random pack_code we have better filter options
+    # We can change/remove this if we get UACS differently or a better solution is found
+    return pack_code_prefix + ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -19,6 +19,7 @@ def create_template(create_url, pack_code, template, notify_template_id=None, ex
 
     if export_file_destination:
         body['exportFileDestination'] = export_file_destination
+
     response = requests.post(create_url, json=body)
     response.raise_for_status()
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are now supporting request personalisation on SMS and email fulfilments as well as print, this PR adds test scenarios and does some refactoring to share more common code.

* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add scenarios for SMS and email fulfilments with personalisation
- Improve testing of SMS and email fulfilments to check the personalisation values in the notify API call
- Refactor to reuse more common code
- Use behave parameter types instead of "manually" converting JSON lists in code 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the linked branches, run the acceptance tests.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/8DGOfdJx/3246-personalisation-on-sms-and-email-fulfilments-8