### PR TITLE
3324 Migrate to registry image

### DIFF
--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -1,7 +1,7 @@
 platform: linux
 
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The concourse resource we use for [docker images](https://github.com/concourse/docker-image-resource) is (or will be) deprecated in favour of [registry-image](https://github.com/concourse/registry-image-resource). We should update our pipelines accordingly.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Switched to use `registry-image` type

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
See deploy PR for test steps

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/4gGdyAR5/3324-concourse-migrate-from-deprecated-docker-image-resource-to-registry-image-ci-pipeline-5