### PR TITLE
Documentation driven context audit logging

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,6 @@
 # Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->
 * [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
-* [ ] [Audit Trail Helper](/acceptance_tests/utilities/audit_trail_helper.py) has been kept up to date
 
 # What has changed
 <!--- What code changes has been made -->

--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -35,7 +35,8 @@ def step_to_do_a_thing(context):
 
 #### Context Index
 
-Every context attribute used by the tests must be described here. This table is parsed into the code to drive audit logging upon failure. 
+Every context attribute used by the tests must be described here. This table is parsed into the code to drive audit
+logging upon failure in the [audit_trail_helper](/acceptance_tests/utilities/audit_trail_helper.py).
 
 <div id="context-index-table">
 

--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -35,36 +35,39 @@ def step_to_do_a_thing(context):
 
 #### Context Index
 
-Every context attribute used by the tests should be described here. Must also be added to the function:
-log_out_user_context_values in audit_trail_helper.py
+Every context attribute used by the tests must be described here. This table is parsed into the code to drive audit logging upon failure. 
 
-| Attribute                          | Description                                                                    |
-|------------------------------------|--------------------------------------------------------------------------------|
-| test_start_utc_datetime            | Stores the UTC time at the beginning of each scenario in an environment hook   |
-| survey_id                          | Stores the ID of the survey generated and or used by the scenario              |
-| collex_id                          | Stores the ID of the collection exercise generated and or used by the scenario |
-| emitted_cases                      | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events              |
-| emitted_uacs                       | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                |
-| pack_code                          | Stores the pack code used for fulfilments or action rules                      |
-| template                           | Stores the column template used for fulfilments or action rules                |
-| telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                |
-| notify_template_id                 | Stores the ID of the sms template used for the notify service                  |
-| fulfilment_response_json           | Stores the response JSON from a `POST` to the Notify API                       |
-| phone_number                       | Stores the phone number needed to check the notify api                         |
-| email                              | Stores the email address needed to check the notify api                        |
-| message_hashes                     | Stores the hash of sent messages, for testing exception management             |
-| correlation_id                     | Stores the ID which connects all related events together                       |
-| originating_user                   | Stores the email of the ONS employee who originally initiated a business event |
-| sent_messages                      | Stores every scenario sent message for debugging errors                        |
-| scenario_name                      | Stores the scenario name and uses it for unique originating users in messages  |
-| case_id                            | Stores the case_id of a case used in the scenario                              |
-| bulk_refusals                      | Stores created bulk refusal cases we expect to see messages for                |
-| bulk_invalids                      | Stores the create bulk invalid cases we expect to see messages for             |
-| bulk_sample_update                 | Stores the create bulk sample update cases we expect to see messages for       |
-| bulk_sensitive_update              | Stores the bulk sensitive update cases we expect to see messages for           |
-| expected_collection_instrument_url | Stores the collection instrument URL expected on emitted `UAC_UPDATE` events   |
-| fulfilment_personalisation         | Stores the personalisation values from a received fulfilment request event     |
-| sample                             | Stores the parsed sample file rows, split into `sample` and `sensitive`        |
+<div id="context-index-table">
+
+| Attribute                          | Description                                                                    | Type     |
+|------------------------------------|--------------------------------------------------------------------------------|----------|
+| test_start_utc_datetime            | Stores the UTC time at the beginning of each scenario in an environment hook   | datetime |
+| survey_id                          | Stores the ID of the survey generated and or used by the scenario              | UUID     |
+| collex_id                          | Stores the ID of the collection exercise generated and or used by the scenario | UUID     |
+| emitted_cases                      | Stores the caseUpdate DTO objects emitted on `CASE_UPDATE` events              | List     |
+| emitted_uacs                       | Stores the UAC DTO objects from the emitted `UAC_UPDATE` events                | List     |
+| pack_code                          | Stores the pack code used for fulfilments or action rules                      | str      |
+| template                           | Stores the column template used for fulfilments or action rules                | Template |
+| telephone_capture_request          | Stores the UAC and QID returned by a telephone capture API call                | Dict     |
+| notify_template_id                 | Stores the ID of the sms template used for the notify service                  | UUID     |
+| fulfilment_response_json           | Stores the response JSON from a `POST` to the Notify API                       | Dict     |
+| phone_number                       | Stores the phone number needed to check the notify api                         | str      |
+| email                              | Stores the email address needed to check the notify api                        | str      |
+| message_hashes                     | Stores the hash of sent messages, for testing exception management             | List     |
+| correlation_id                     | Stores the ID which connects all related events together                       | UUID     |
+| originating_user                   | Stores the email of the ONS employee who originally initiated a business event | str      |
+| sent_messages                      | Stores every scenario sent message for debugging errors                        | List     |
+| scenario_name                      | Stores the scenario name and uses it for unique originating users in messages  | str      |
+| case_id                            | Stores the case_id of a case used in the scenario                              | UUID     |
+| bulk_refusals                      | Stores created bulk refusal cases we expect to see messages for                | List     |
+| bulk_invalids                      | Stores the create bulk invalid cases we expect to see messages for             | List     |
+| bulk_sample_update                 | Stores the create bulk sample update cases we expect to see messages for       | List     |
+| bulk_sensitive_update              | Stores the bulk sensitive update cases we expect to see messages for           | List     |
+| expected_collection_instrument_url | Stores the collection instrument URL expected on emitted `UAC_UPDATE` events   | str      |
+| fulfilment_personalisation         | Stores the personalisation values from a received fulfilment request event     | Dict     |
+| sample                             | Stores the parsed sample file rows, split into `sample` and `sensitive`        | List     |
+
+</div>
 
 ### Sharing Code Between Steps
 

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test_core: package_vulnerability lint at_tests_core
 test: package_vulnerability lint at_tests
 
 at_tests:
-	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features --logging-level WARN
+	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
 
 at_tests_core:
-	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
+	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN --tags="~@regression"
 
 build:
 	docker build -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests .

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -7,7 +7,7 @@ import requests
 from behave import register_type
 from structlog import wrap_logger
 
-from acceptance_tests.utilities.audit_trail_helper import log_out_user_context_values
+from acceptance_tests.utilities.audit_trail_helper import log_out_user_context_values, parse_markdown_context_table
 from acceptance_tests.utilities.exception_manager_helper import get_bad_messages, \
     quarantine_bad_messages_check_and_reset
 from acceptance_tests.utilities.notify_helper import reset_notify_stub
@@ -21,6 +21,8 @@ logger = wrap_logger(logging.getLogger(__name__))
 register_type(boolean=strtobool)
 register_type(json=parse_json_object)
 register_type(array=parse_array_to_list)
+
+CONTEXT_ATTRIBUTES = parse_markdown_context_table(Config.CODE_GUIDE_MARKDOWN_FILE_PATH)
 
 
 def move_fulfilment_triggers_harmlessly_massively_into_the_future():
@@ -52,7 +54,7 @@ def after_all(_context):
 
 def after_scenario(context, scenario):
     if getattr(scenario, 'status') == 'failed':
-        log_out_user_context_values(context)
+        log_out_user_context_values(context, CONTEXT_ATTRIBUTES)
 
     unexpected_bad_messages = get_bad_messages()
 

--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -1,6 +1,8 @@
 import logging
 import random
 import string
+from pathlib import Path
+from typing import Dict, List
 
 from structlog import wrap_logger
 
@@ -22,39 +24,23 @@ def get_random_alpha_numerics(length=4):
     return "".join(random.choices(string.ascii_uppercase + string.digits, k=length))
 
 
-def log_out_user_context_values(context):
-    # TODO Could this be combined this with the CODE Style documentation?
-    # Set up a list of context vars Name, Type (string/json/list, description)?
-    # This would document and allow consistent outputting of these values in one?
-
+def log_out_user_context_values(context, context_attributes: List[Dict]):
     logger.error('Outputting user context vars')
-
-    context_output = "\n"
-    context_output += get_context_value(context, 'test_start_utc_datetime')
-    context_output += get_context_value(context, 'survey_id')
-    context_output += get_context_value(context, 'collex_id')
-    context_output += get_context_list_value(context, 'emitted_cases')
-    context_output += get_context_list_value(context, 'emitted_uacs')
-    context_output += get_context_value(context, 'pack_code')
-    context_output += get_context_value(context, 'template')
-    context_output += get_context_value(context, 'telephone_capture_request')
-    context_output += get_context_value(context, 'notify_template_id')
-    context_output += get_context_value(context, 'sms_fulfilment_response_json')
-    context_output += get_context_value(context, 'phone_number')
-    context_output += get_context_list_value(context, 'message_hashes')
-    context_output += get_context_value(context, 'correlation_id')
-    context_output += get_context_value(context, 'originating_user')
-    context_output += get_context_list_value(context, 'sent_messages')
-    context_output += get_context_value(context, 'case_id')
-    context_output += get_context_list_value(context, 'bulk_refusals')
-    context_output += get_context_list_value(context, 'bulk_invalids')
-    context_output += get_context_list_value(context, 'bulk_sample_update')
-    context_output += get_context_list_value(context, 'bulk_sensitive_update')
-    context_output += get_context_value(context, 'expected_collection_instrument_url')
-    context_output += get_context_value(context, 'fulfilment_personalisation')
-    context_output += get_context_list_value(context, 'sample')
+    context_output = build_context_audit_log(context, context_attributes)
 
     logger.error(context_output)
+
+
+def build_context_audit_log(context, context_attributes: List[Dict]) -> str:
+    context_output = "\n"
+
+    for context_attribute in context_attributes:
+        if context_attribute['Type'] == 'List':
+            context_output += get_context_list_value(context, context_attribute['Attribute'])
+        else:
+            context_output += get_context_value(context, context_attribute['Attribute'])
+
+    return context_output
 
 
 def get_context_value(context, key):
@@ -65,7 +51,6 @@ def get_context_value(context, key):
 
 
 def get_context_list_value(context, key):
-
     if not hasattr(context, key):
         return f"context.{key} not set. \n"
 
@@ -77,3 +62,47 @@ def get_context_list_value(context, key):
         list_values += f'   context.{key}{[i]}:   {context_list_var[i]} \n'
 
     return list_values
+
+
+def parse_markdown_context_table(code_guide_markdown_path: Path) -> List[Dict]:
+    with open(code_guide_markdown_path) as code_guide_markdown:
+        # Find the start of the table
+        for line in code_guide_markdown:
+            # The start of the table is identified with a div tag
+            if line == '<div id="context-index-table">\n':
+                break
+        else:
+            raise ValueError('Failed to find `<div id="context-index-table">\\n` in code guide markdown')
+
+        # Skip the blank line after the div tag
+        next(code_guide_markdown)
+
+        # Parse the header
+        raw_header_row = next(code_guide_markdown)
+        header_fields = tuple(parse_markdown_table_row(raw_header_row))
+        required_header_fields = {'Attribute', 'Type'}
+        if not set(header_fields).issuperset(required_header_fields):
+            raise ValueError(
+                f'Context table missing required fields, requires: {required_header_fields}, got: {header_fields}')
+
+        # Skip the separator line between the table header and body
+        next(code_guide_markdown)
+
+        # Parse the table body
+        context_guide = []
+        for table_row in code_guide_markdown:
+
+            # Break out at the end of the table
+            if not table_row.rstrip('\n'):
+                break
+
+            columns = parse_markdown_table_row(table_row)
+            context_guide.append(dict(zip(header_fields, columns)))
+        else:
+            raise ValueError('Error parsing context attribute table markdown, did not reach end of table')
+
+        return context_guide
+
+
+def parse_markdown_table_row(table_row: str) -> List:
+    return [column.strip() for column in table_row.split('|')[1:-1]]

--- a/acceptance_tests/utilities/audit_trail_helper.py
+++ b/acceptance_tests/utilities/audit_trail_helper.py
@@ -68,11 +68,12 @@ def parse_markdown_context_table(code_guide_markdown_path: Path) -> List[Dict]:
     with open(code_guide_markdown_path) as code_guide_markdown:
         # Find the start of the table
         for line in code_guide_markdown:
+
             # The start of the table is identified with a div tag
             if line == '<div id="context-index-table">\n':
                 break
         else:
-            raise ValueError('Failed to find `<div id="context-index-table">\\n` in code guide markdown')
+            raise ValueError('Failed to find `<div id="context-index-table">` in code guide markdown')
 
         # Skip the blank line after the div tag
         next(code_guide_markdown)
@@ -92,7 +93,7 @@ def parse_markdown_context_table(code_guide_markdown_path: Path) -> List[Dict]:
         context_guide = []
         for table_row in code_guide_markdown:
 
-            # Break out at the end of the table
+            # Break out when we hit the empty line at the end of the table
             if not table_row.rstrip('\n'):
                 break
 
@@ -101,8 +102,12 @@ def parse_markdown_context_table(code_guide_markdown_path: Path) -> List[Dict]:
         else:
             raise ValueError('Error parsing context attribute table markdown, did not reach end of table')
 
-        return context_guide
+    return context_guide
 
 
 def parse_markdown_table_row(table_row: str) -> List:
+    # Table rows are expected to be in the format:
+    # | foo   | bar      |
+    # We split on the pipe characters, throw away the empty first and last values either side of the table edges,
+    # then strip out any whitespace either side of the values
     return [column.strip() for column in table_row.split('|')[1:-1]]

--- a/config.py
+++ b/config.py
@@ -71,3 +71,6 @@ class Config:
     RESOURCE_FILE_PATH = Path(os.getenv('RESOURCE_FILE_PATH') or Path(__file__).parent.joinpath('resources'))
 
     SAMPLE_LOAD_ORIGINATING_USER = os.getenv('ORIGINATING_USER', 'dummy@fake-email.com')
+
+    CODE_GUIDE_MARKDOWN_FILE_PATH = Path(
+        os.getenv('CODE_GUIDE_MARKDOWN_FILE_PATH') or Path(__file__).parent.joinpath('CODE_GUIDE.md'))

--- a/run.py
+++ b/run.py
@@ -6,7 +6,6 @@ from behave import __main__ as behave_executable
 DEFAULT_LOG_LEVEL = 'INFO'
 DEFAULT_BEHAVE_FORMAT = 'pretty'
 DEFAULT_FEATURE_DIRECTORY = 'acceptance_tests/features'
-DEFAULT_TAGS = '~@regression'
 
 
 def parse_arguments():
@@ -18,7 +17,7 @@ def parse_arguments():
     parser.add_argument('--log_level', '-l', help='Logging level', default=DEFAULT_LOG_LEVEL)
     parser.add_argument('--format', '-f', help='Behave format', default=DEFAULT_BEHAVE_FORMAT)
     parser.add_argument('--feature_directory', '-fd', help='Feature directory', default=DEFAULT_FEATURE_DIRECTORY)
-    parser.add_argument('--tags', '-t', help='Tags', default=DEFAULT_TAGS)
+    parser.add_argument('--tags', '-t', help='Tags')
     parser.add_argument('--show_skipped', help='Show skipped tests', action='store_true')
 
     return parser.parse_args()

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -38,6 +38,6 @@ run:
       kubectl wait --for=condition=Ready pod/acceptance-tests --timeout=200s
 
       kubectl exec -it acceptance-tests -- /bin/bash -c \
-      "sleep 2; behave acceptance_tests/features --no-skipped --no-logcapture --logging-level WARN  ${BEHAVE_TAGS}"
+      "sleep 2; behave acceptance_tests/features --no-skipped --no-logcapture --logging-level WARN ${BEHAVE_TAGS}"
 
       kubectl delete pod acceptance-tests || true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

We have been maintaining a record of the context vars we use in both the code guide markdown and in the code in order to format and output a helpful audit log of the test context upon failure. This PR aims to make that managed in one place, in the code guide, so that it stays more consistent and up to date. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Parse the context index markdown table from the code guide into the tests to drive the context audit logging
- Fix the acceptance test tag args and makefile to run it more consistently

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Sprinkle some `assert False` lines into the tests to induce some failures, then run them from the command line and check the logs of the failures. It should be outputting the full set of context vars as before, but now driven by the markdown table. 

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/FRVJp3tj/3388-generate-acceptance-test-context-audit-logging-from-markdown-table