### PR TITLE
make not running RH default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ test_core: package_vulnerability lint at_tests_core
 test: package_vulnerability lint at_tests
 
 at_tests:
-	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
+	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN --tags="~@rh"
 
 at_tests_core:
 	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN --tags="~@rh,~@regression"
 
-at_tests_rm:
-	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN --tags="~@rh"
+at_tests_with_rh:
+	PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
 
 build:
 	docker build -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests .


### PR DESCRIPTION
# Motivation and Context
CI broken
In CI RH tests shouldn't run,  easiest thing is to make the default make at_tests ignore RH tests

# What has changed
moved around so the tests for RH need to be explicitly run locally with at_tests_with_rh make at_tests will ignore them

# How to test?
run commands