### PR TITLE
Increase PubSub timeout again

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ ENV=<YOUR_ENV_SUFFIX> REGRESSION=true ./run_gke.sh
 ### With Local Changes
 
 To run a locally-modified version of the acceptance tests in a pod you will have to build and tag the image, push it to
-the GCR and change the image in [acceptance_tests_pod.yml](./acceptance_tests_pod.yml) to point to your modified image tag.
+the GCR and change the image in [acceptance_tests_pod.yml](./acceptance_tests_pod.yml) to point to your modified image
+tag.
 
 ```shell script
 IMAGE_TAG=<YOUR_TAG>
@@ -105,3 +106,11 @@ PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features 
 provided in multiple args like `--tags @foo --tags @bar` are combined with an `AND`, and multiple negative tags
 like `~@foo` can only be combined with `AND` in multiple, separate tags args.
 See [Behave Tag Expressions](https://behave.readthedocs.io/en/stable/behave.html#tag-expression).
+
+### PubSub Pull Timeout
+
+The default timeout on the tests waiting for expected PubSub messages is set long to improve reliability in
+potentially "cold" cloud environments. However, this may be impractical for local runs or development as the tests may
+be very slow to fail. You can override this by setting `PUBSUB_DEFAULT_PULL_TIMEOUT` in the test environment to a
+smaller value such as `10` (seconds), since a local PubSub emulator or "warmed up" cloud environment should not need
+such a long wait for messages.

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -10,6 +10,7 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 from structlog import wrap_logger
+
 logger = wrap_logger(logging.getLogger(__name__))
 
 
@@ -90,7 +91,7 @@ def _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_c
     return received_messages
 
 
-def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeout=60):
+def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeout=Config.PUBSUB_DEFAULT_PULL_TIMEOUT):
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(Config.PUBSUB_PROJECT, subscription)
     received_messages = _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_count, timeout)
@@ -105,7 +106,7 @@ def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeou
 
 
 def get_matching_pubsub_message_acking_others(subscription, message_matcher: Callable[[Mapping], tuple[bool, str]],
-                                              timeout=60):
+                                              timeout=Config.PUBSUB_DEFAULT_PULL_TIMEOUT):
     """
     Pull and ack all pubsub messages on the given subscription within the timeout, until a match is found
     message_matcher is a function which takes the parsed message body json and returns a bool for whether it matches,

--- a/config.py
+++ b/config.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 
 class Config:
-
     EVENT_SCHEMA_VERSION = "0.5.0"
 
     PUBSUB_PROJECT = os.getenv('PUBSUB_PROJECT', 'shared-project')
@@ -27,6 +26,7 @@ class Config:
     PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION = os.getenv('PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION',
                                                                  'event_collection-exercise-update_rh_at')
     PUBSUB_NEW_CASE_TOPIC = os.getenv('PUBSUB_NEW_CASE_TOPIC', 'event_new-case')
+    PUBSUB_DEFAULT_PULL_TIMEOUT = int(os.getenv('PUBSUB_DEFAULT_PULL_TIMEOUT', 120))
 
     DB_USERNAME = os.getenv('DB_USERNAME', 'postgres')
     DB_PASSWORD = os.getenv('DB_PASSWORD', 'postgres')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
The tests are still proving unreliable on "cold" cloud infrastructure, we need to increase the default waits again.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Increase PubSub default timeout
- Make it configurable
- Document it

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Should be no local change when the tests are passing, if they fail to find an expected message they will now be very slow to fail, hence making that wait configurable so it can be adjusted to fail faster locally if needed.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Psup0S5A/106-increase-at-pubsub-timeout-again