### PR TITLE
Remove pubsub timeout overrides

### DIFF
--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -9,8 +9,7 @@ from config import Config
 
 def get_emitted_cases(expected_msg_count=1):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                                            expected_msg_count=expected_msg_count,
-                                                            timeout=60)
+                                                            expected_msg_count=expected_msg_count)
 
     case_payloads = []
     for message_received in messages_received:
@@ -53,8 +52,7 @@ def get_emitted_uac_update(correlation_id, originating_user):
 
 def get_uac_update_events(expected_number, correlation_id, originating_user):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
-                                                            expected_msg_count=expected_number,
-                                                            timeout=60)
+                                                            expected_msg_count=expected_number)
 
     uac_payloads = []
     for uac_event in messages_received:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Some of the calls were overriding the default pubsub timeout to a shorter value, causing failures on cold infrastructure.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Remove pubsub timeout overrides

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/801hWiIb/124-at-pubsub-timeouts-fix