### PR TITLE
284 Use commit ref image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ setenvs.sh
 
 # Bulk Test CSV Files
 *bulk_test.csv
+
+# Temporary manifests
+tmp_*_acceptance_tests_pod.yml

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ By default, this will run the core RM tests, you can run the full suite of RM re
 ENV=<YOUR_ENV_SUFFIX> REGRESSION=true ./run_gke.sh
 ```
 
+By default the script will use the `latest` tagged acceptance tests image, you can optionally pass in a custom image tag
+like so to override it:
+
+```shell
+ENV=<YOUR_ENV_SUFFIX> ./run_gke.sh <custom_image_tag>
+```
+
 ### With Local Changes
 
 To run a locally-modified version of the acceptance tests in a pod you will have to build and tag the image, push it to

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -22,7 +22,7 @@ spec:
               cp /home/acceptancetests/postgresql/* /home/acceptancetests/.postgresql
               chmod 0600 /home/acceptancetests/.postgresql/postgresql.key
               # the above is a workaround to get round the permissions as currently we cant mount it without doing this
-    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:latest
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:$MANIFEST_IMAGE_TAG
     tty: true
     stdin: true
     imagePullPolicy: Always

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -27,17 +27,26 @@ run:
       # Use gcloud service account to configure kubectl
       gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+      
+      
+      # Use the commit hash as the image tag in the K8s manifest
+      IMAGE_TAG=$(cat acceptance-tests-repo/.git/ref)
+      COMPLETE_MANIFEST="${IMAGE_TAG}_acceptance_tests_pod.yml"
+      sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" acceptance_tests_pod.yml > $COMPLETE_MANIFEST
 
-      # Create an acceptance tests pod and run the acceptance tests in it
-      # The sleep is to give kubectl time to attach properly, otherwise the first few log lines are lost
-
+      # Pre-clean up any left over acceptance test pod
       kubectl delete pod acceptance-tests --wait || true
 
-      kubectl apply -f acceptance-tests-repo/acceptance_tests_pod.yml
-
+      # Create an acceptance tests pod using the manifest with image substituted in
+      kubectl apply -f $COMPLETE_MANIFEST
+      
+      # Give the pod time to start
       kubectl wait --for=condition=Ready pod/acceptance-tests --timeout=200s
 
+      # Exec into the pod to run the tests while tailing their logs
+      # The sleep is to give kubectl time to attach properly, otherwise the first few log lines are lost
       kubectl exec -it acceptance-tests -- /bin/bash -c \
       "sleep 2; behave acceptance_tests/features --logging-level WARN ${BEHAVE_TAGS}"
-
+  
+      # Clean up the pod once we're finished
       kubectl delete pod acceptance-tests || true

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -6,11 +6,14 @@ image_resource:
     repository: gcr.io/google.com/cloudsdktool/cloud-sdk
 
 params:
-  SERVICE_ACCOUNT_JSON:
-  GCP_PROJECT_NAME:
-  KUBERNETES_CLUSTER:
-  ACCEPTANCE_TESTS_IMAGE:
-  BEHAVE_TAGS:
+  # Required
+  SERVICE_ACCOUNT_JSON: # GCP service account key JSON
+  GCP_PROJECT_NAME: # Target project which hosts the K8s cluster
+  KUBERNETES_CLUSTER: # Target K8s cluster ID
+
+  # Optional
+  IMAGE_TAG: # Optional, specific acceptance tests image tag. If not set, will default to using the given commit ref from the "acceptance-tests-repo"
+  BEHAVE_TAGS: # Optional, list of behave tags passed into the behave feature run
 
 inputs:
 - name: acceptance-tests-repo
@@ -27,17 +30,20 @@ run:
       # Use gcloud service account to configure kubectl
       gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}
+
+      if [ -z "$IMAGE_TAG" ]; then
+        # If no explicit tag is set then use the commit ref
+        IMAGE_TAG=$(cat acceptance-tests-repo/.git/ref)
+      fi
       
-      
-      # Use the commit hash as the image tag in the K8s manifest
-      IMAGE_TAG=$(cat acceptance-tests-repo/.git/ref)
+      # Substitute the image tag into the template manifest yaml
       COMPLETE_MANIFEST="${IMAGE_TAG}_acceptance_tests_pod.yml"
       sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" acceptance_tests_pod.yml > $COMPLETE_MANIFEST
 
       # Pre-clean up any left over acceptance test pod
       kubectl delete pod acceptance-tests --wait || true
 
-      # Create an acceptance tests pod using the manifest with image substituted in
+      # Create an acceptance tests pod using the manifest with image tag substituted in
       kubectl apply -f $COMPLETE_MANIFEST
       
       # Give the pod time to start


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

We want to avoid `latest` image tags in our CI, use the commit ref instead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Template the image tag in the pod manifest
- Use the commit ref as the image tag in the concourse task
- Update `run_gke.sh` script to use `latest` image tag by default and have optional image tag arg
- Update README

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Try the `run_gke.sh` script, try the concourse job.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/yyKcXZNF/195-use-commit-hash-tags-instead-of-latest-for-ci-int-deployments-8-ah