### PR TITLE
298 Fix tests not consuming launch UAC update

### DIFF
--- a/acceptance_tests/features/RH_UI.feature
+++ b/acceptance_tests/features/RH_UI.feature
@@ -19,6 +19,7 @@ Feature: Testing the "enter a UAC" functionality of RH UI
     When the UAC entry page is displayed
     And the user enters a valid UAC
     Then they are redirected to EQ with the correct token
+    And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
 
   @reset_notify_stub
   Scenario: A receipted UAC redirects to informative page

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -43,12 +43,14 @@ def is_redirected_to_EQ(context):
         len(query_strings['token']), 1,
         f'Expected to find exactly 1 token in the launch URL query stings, actual launch url: {context.browser.url}')
 
-    decrypt_claims_token_and_check_contents(context.rh_launch_qid,
-                                            context.emitted_cases[0][
-                                                'caseId'],
-                                            context.collex_id,
-                                            query_strings['token'][
-                                                0])
+    eq_claims = decrypt_claims_token_and_check_contents(context.rh_launch_qid,
+                                                        context.emitted_cases[0][
+                                                            'caseId'],
+                                                        context.collex_id,
+                                                        query_strings['token'][
+                                                            0])
+
+    context.correlation_id = eq_claims['tx_id']
 
 
 @step("the user enters a receipted UAC")


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

Launching in RH UI generates a UAC update, this must be checked and consumed otherwise it can polute future tests.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Consume the UAC update generated by the RH UI launch

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the updated scenario. Running locally likely would not show the issue with not consuming the message, as we attempt to purge messages after every scenario and this works a lot more reliably against the local emulator than against real cloud PubSub.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/9GXrJ4GH/298-ats-dont-consume-uac-update-after-rh-ui-launch