### PR TITLE
234-receiving-receipts

### DIFF
--- a/acceptance_tests/utilities/jwe_helper.py
+++ b/acceptance_tests/utilities/jwe_helper.py
@@ -25,9 +25,11 @@ def decrypt_claims_token_and_check_contents(rh_launch_qid: str, case_id: str, co
     test_helper.assertEqual(eq_claims['survey_metadata']['data']['questionnaire_id'], rh_launch_qid,
                             f'Expected to find the correct QID in the claims payload, actual payload: {eq_claims}')
 
-    test_helper.assertEqual(eq_claims['survey_metadata']["receipting_keys"], ['questionnaire_id'],
+    test_helper.assertEqual(eq_claims['survey_metadata']["receipting_keys"], ['questionnaire_id', 'source'],
                             f'Expected to find the questionnaire_id as receipting key in claims payload, '
                             f'actual payload: {eq_claims}')
+    test_helper.assertEqual(eq_claims['survey_metadata']['data']['source'], "SRM",
+                            f'Expected to find the correct source in the claims payload, actual payload: {eq_claims}')
 
     test_helper.assertEqual(eq_claims['collection_exercise_sid'], collex_id,
                             'Expected to find the correct collection exercise ID in the claims payload, '


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
For SDX to know it's a receipt from an adhoc survey, we're going to add a source to the survey metadata to the eqpayload so  it can be sent to SDX as well. 
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added `source` to receipting keys and survey_metadata data
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the ATs with the RH branch and all tests should pass
- Enter in a UAC into RH-UI and get the token from the url. In ssdc-rm-dev-tools, use the decrypt token script and you should see the source in the payload
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/5MWC8p2n/)

