### PR TITLE
366 Fix Support Tool UI Scenario Failure

### DIFF
--- a/acceptance_tests/features/RH_UI.feature
+++ b/acceptance_tests/features/RH_UI.feature
@@ -4,7 +4,7 @@ Feature: Testing the "enter a UAC" functionality of RH UI
   Scenario: Entering a bad UAC and error section displayed
     Given the UAC entry page is displayed
     When the user enters UAC "PK39HN572FZFVHLQ"
-    Then An error section is displayed with href "#uac_invalid" is displayed with "Enter a valid access code"
+    Then an error section is displayed with href "#uac_invalid" is displayed with "Enter a valid access code"
     And link text displays string "Enter a valid access code"
 
   @reset_notify_stub
@@ -55,4 +55,4 @@ Feature: Testing the "enter a UAC" functionality of RH UI
   Scenario: No access code entered
     Given the UAC entry page is displayed
     When the user clicks Access Survey without entering a UAC
-    Then An error section is displayed with href "#uac_empty" is displayed with "Enter an access code"
+    Then an error section is displayed with href "#uac_empty" is displayed with "Enter an access code"

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -7,7 +7,7 @@ Feature: Test basic Support Tool Functionality
     And a Survey called "CreateSurveyTest" plus unique suffix is created for sample file "social_sample_3_lines_fields.csv" with sensitive columns []
     When the survey is clicked on it should display the collection exercise page
     And the create collection exercise button is clicked, the details are submitted and the exercise is created
-    And the collection exercise is clicked on and displays the details page
+    And the collection exercise is clicked on, navigating to the selected exercise details page
     Then I click the upload sample file button with file "social_sample_3_lines_fields.csv"
 
   Scenario: Create an export file template
@@ -26,7 +26,7 @@ Feature: Test basic Support Tool Functionality
     And the survey is clicked on it should display the collection exercise page
     And the create collection exercise button is clicked, the details are submitted and the exercise is created
     And the export file template has been added to the allow on action rule list
-    And the collection exercise is clicked on and displays the details page
+    And the collection exercise is clicked on, navigating to the selected exercise details page
     And I click the upload sample file button with file "social_sample_3_lines_fields.csv"
     When I create an action rule
     Then I can see the Action Rule has been triggered and export files been created
@@ -42,7 +42,7 @@ Feature: Test basic Support Tool Functionality
     And the survey is clicked on it should display the collection exercise page
     And the create collection exercise button is clicked, the details are submitted and the exercise is created
     And the email template has been added to the allow on action rule list
-    And the collection exercise is clicked on and displays the details page
+    And the collection exercise is clicked on, navigating to the selected exercise details page
     And I click the upload sample file button with file "sis_survey_link.csv"
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -10,13 +10,13 @@ Feature: Test basic Support Tool Functionality
     And the collection exercise is clicked on and displays the details page
     Then I click the upload sample file button with file "social_sample_3_lines_fields.csv"
 
-  Scenario: Creating an export file template
+  Scenario: Create an export file template
     Given the support tool landing page is displayed
     And the Create Export File Template button is clicked on
     When an export file template with packcode "export-file-packcode" and template ["__uac__"] has been created
     Then I should see the export file template in the template list
 
-  Scenario: Creating an Export File Action Rule
+  Scenario: Create an Export File Action Rule
     Given the support tool landing page is displayed
     And the Create Export File Template button is clicked on
     And an export file template with packcode "export-file-packcode" and template ["__uac__"] has been created
@@ -32,7 +32,7 @@ Feature: Test basic Support Tool Functionality
     Then I can see the Action Rule has been triggered and export files been created
 
   @reset_notify_stub
-  Scenario: Creating an Email Action Rule
+  Scenario: Create an Email Action Rule
     Given the support tool landing page is displayed
     And the Create Email Template button is clicked on
     And an email template with packcode "email-packcode" and template ["__uac__"] has been created

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -3,11 +3,11 @@ Feature: Test basic Support Tool Functionality
 
   Scenario: Create a Survey, Collection Exercise and Load a Sample
     Given the support tool landing page is displayed
-    And The Create Survey Button is clicked on
+    And the Create Survey Button is clicked on
     And a Survey called "CreateSurveyTest" plus unique suffix is created for sample file "social_sample_3_lines_fields.csv" with sensitive columns []
-    When the survey is clicked on it should display the collex page
-    And the create collection exercise button is clicked on and entered in details
-    And the collex is clicked on and displays the details page
+    When the survey is clicked on it should display the collection exercise page
+    And the create collection exercise button is clicked, the details are submitted and the exercise is created
+    And the collection exercise is clicked on and displays the details page
     Then I click the upload sample file button with file "social_sample_3_lines_fields.csv"
 
   Scenario: Creating an export file template
@@ -21,12 +21,12 @@ Feature: Test basic Support Tool Functionality
     And the Create Export File Template button is clicked on
     And an export file template with packcode "export-file-packcode" and template ["__uac__"] has been created
     And I should see the export file template in the template list
-    And The Create Survey Button is clicked on
+    And the Create Survey Button is clicked on
     And a Survey called "ActionRuleTest" plus unique suffix is created for sample file "social_sample_3_lines_fields.csv" with sensitive columns []
-    And the survey is clicked on it should display the collex page
-    And the create collection exercise button is clicked on and entered in details
+    And the survey is clicked on it should display the collection exercise page
+    And the create collection exercise button is clicked, the details are submitted and the exercise is created
     And the export file template has been added to the allow on action rule list
-    And the collex is clicked on and displays the details page
+    And the collection exercise is clicked on and displays the details page
     And I click the upload sample file button with file "social_sample_3_lines_fields.csv"
     When I create an action rule
     Then I can see the Action Rule has been triggered and export files been created
@@ -37,12 +37,12 @@ Feature: Test basic Support Tool Functionality
     And the Create Email Template button is clicked on
     And an email template with packcode "email-packcode" and template ["__uac__"] has been created
     And I should see the email template in the template list
-    And The Create Survey Button is clicked on
+    And the Create Survey Button is clicked on
     And a Survey called "EmailTest" plus unique suffix is created for sample file "sis_survey_link.csv" with sensitive columns ["emailAddress"]
-    And the survey is clicked on it should display the collex page
-    And the create collection exercise button is clicked on and entered in details
+    And the survey is clicked on it should display the collection exercise page
+    And the create collection exercise button is clicked, the details are submitted and the exercise is created
     And the email template has been added to the allow on action rule list
-    And the collex is clicked on and displays the details page
+    And the collection exercise is clicked on and displays the details page
     And I click the upload sample file button with file "sis_survey_link.csv"
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -78,7 +78,7 @@ def enter_no_uac(context):
     context.browser.find_by_id('uac').fill(RETURN)
 
 
-@step('An error section is displayed with href "{href_name}" is displayed with "{expected_text}"')
+@step('an error section is displayed with href "{href_name}" is displayed with "{expected_text}"')
 def error_section_displayed(context, href_name, expected_text):
     test_helper.assertEqual(context.browser.find_by_id('error-summary-title').text, 'There is a problem with this page')
     error_text = context.browser.links.find_by_href(href_name).text

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -86,7 +86,7 @@ def click_create_collex_button(context):
     get_emitted_collection_exercise_update()
 
 
-@step('the collection exercise is clicked on and displays the details page')
+@step('the collection exercise is clicked on, navigating to the selected exercise details page')
 def click_into_collex_details(context):
     context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name).click()
 

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -4,24 +4,26 @@ from datetime import datetime
 from typing import List
 
 from behave import step
-from tenacity import retry, wait_fixed, stop_after_delay
+from tenacity import retry, stop_after_delay, wait_fixed
 
 from acceptance_tests.features.steps.email_action_rule import check_notify_called_with_correct_emails_and_uacs
 from acceptance_tests.features.steps.export_file import check_export_file
 from acceptance_tests.utilities.audit_trail_helper import get_random_alpha_numerics
-from acceptance_tests.utilities.event_helper import get_emitted_cases, get_uac_update_events
+from acceptance_tests.utilities.event_helper import get_emitted_cases, get_emitted_collection_exercise_update, \
+    get_uac_update_events
 from acceptance_tests.utilities.sample_helper import read_sample
+from acceptance_tests.utilities.survey_helper import get_emitted_survey_update
 from acceptance_tests.utilities.test_case_helper import test_helper
 from acceptance_tests.utilities.validation_rule_helper import get_sample_rows_and_generate_open_validation_rules
 from config import Config
 
 
 @step("the support tool landing page is displayed")
-def support_tool_landing_page_navigated_to(context):
+def navigate_to_support_tool_landing_page(context):
     context.browser.visit(f'{Config.SUPPORT_TOOL_URL}')
 
 
-@step("The Create Survey Button is clicked on")
+@step("the Create Survey Button is clicked on")
 def click_on_create_survey_button(context):
     context.browser.find_by_id('createSurveyBtn').click()
 
@@ -46,13 +48,15 @@ def create_survey_in_UI(context, survey_prefix, sample_file_name, sensitive_colu
     test_helper.assertEquals(
         len(context.browser.find_by_id('surveyListTable').first.find_by_text(context.survey_name, wait_time=20)), 1)
 
+    get_emitted_survey_update(context.survey_name)
 
-@step('the survey is clicked on it should display the collex page')
+
+@step('the survey is clicked on it should display the collection exercise page')
 def click_into_collex_page(context):
     context.browser.find_by_id('surveyListTable').first.find_by_text(context.survey_name).click()
 
 
-@step('the create collection exercise button is clicked on and entered in details')
+@step('the create collection exercise button is clicked, the details are submitted and the exercise is created')
 def click_create_collex_button(context):
     context.browser.find_by_id('createCollectionExerciseBtn').click()
     context.collex_name = 'test collex ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
@@ -79,8 +83,10 @@ def click_create_collex_button(context):
     test_helper.assertEquals(
         len(context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name)), 1)
 
+    get_emitted_collection_exercise_update()
 
-@step('the collex is clicked on and displays the details page')
+
+@step('the collection exercise is clicked on and displays the details page')
 def click_into_collex_details(context):
     context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name).click()
 
@@ -112,7 +118,7 @@ def click_create_export_file_template_button(context):
 
 
 @step('an export file template with packcode "{packcode}" and template {template:array} has been created')
-def creating_export_file_template(context, packcode, template: List):
+def create_export_file_template(context, packcode, template: List):
     context.pack_code = f'{packcode}-' + get_random_alpha_numerics(5)
     context.template = template
     context.browser.find_by_id('packCodeTextField').fill(context.pack_code)
@@ -124,13 +130,13 @@ def creating_export_file_template(context, packcode, template: List):
 
 
 @step('I should see the export file template in the template list')
-def finding_created_export_file(context):
+def find_created_export_file(context):
     test_helper.assertEquals(
         len(context.browser.find_by_id('exportFileTemplateTable').first.find_by_text(context.pack_code)), 1)
 
 
 @step("the export file template has been added to the allow on action rule list")
-def allowing_export_file_template_on_action_rule(context):
+def allow_export_file_template_on_action_rule(context):
     context.browser.find_by_id('actionRuleExportFileTemplateBtn').click()
     context.browser.find_by_id('allowExportFileTemplateSelect').click()
     context.browser.find_by_value(context.pack_code).click()
@@ -138,7 +144,7 @@ def allowing_export_file_template_on_action_rule(context):
 
 
 @step("I create an action rule")
-def clicking_action_rule_button(context):
+def click_action_rule_button(context):
     context.browser.find_by_id('createActionRuleDialogBtn').click()
     context.browser.find_by_id('selectActionRuleType').click()
     context.browser.find_by_value('Export File').click()
@@ -148,7 +154,7 @@ def clicking_action_rule_button(context):
 
 
 @step('I can see the Action Rule has been triggered and export files been created')
-def checking_for_action_rule_triggered(context):
+def check_for_action_rule_triggered(context):
     poll_action_rule_trigger(context.browser, context.pack_code)
     context.emitted_uacs = get_uac_update_events(context.sample_count, None, None)
     check_export_file(context)
@@ -168,7 +174,7 @@ def click_create_email_template_button(context):
 
 
 @step('an email template with packcode "{packcode}" and template {template:array} has been created')
-def creating_email_template(context, packcode, template: List):
+def create_email_template(context, packcode, template: List):
     context.pack_code = f'{packcode}-' + get_random_alpha_numerics(5)
     context.template = template
     context.notify_template_id = str(uuid.uuid4())
@@ -181,21 +187,21 @@ def creating_email_template(context, packcode, template: List):
 
 
 @step('I should see the email template in the template list')
-def finding_created_email_template(context):
+def find_created_email_template(context):
     test_helper.assertEquals(
         len(context.browser.find_by_id('emailTemplateTable').first.find_by_text(context.pack_code)), 1)
 
 
 @step("the email template has been added to the allow on action rule list")
-def allowing_email_template_on_action_rule(context):
+def allow_email_template_on_action_rule(context):
     context.browser.find_by_id('allowEmailTemplateDialogBtn').click()
     context.browser.find_by_id('selectEmailTemplate').click()
-    context.browser.find_by_value(context.pack_code).click()
+    context.browser.find_by_id(context.pack_code).click()
     context.browser.find_by_id("allowEmailTemplateOnActionRule").click()
 
 
 @step('I create an email action rule with email column "{email_column}"')
-def clicking_email_action_rule_button(context, email_column):
+def click_email_action_rule_button(context, email_column):
     context.browser.find_by_id('createActionRuleDialogBtn').click()
     context.browser.find_by_id('selectActionRuleType').click()
     context.browser.find_by_value('Email').click()
@@ -207,6 +213,6 @@ def clicking_email_action_rule_button(context, email_column):
 
 
 @step('I can see the Action Rule has been triggered and emails sent to notify api with email column "{email_column}"')
-def checking_for_action_rule_triggered_for_email(context, email_column):
+def check_action_rule_triggered_for_email(context, email_column):
     poll_action_rule_trigger(context.browser, context.pack_code)
     check_notify_called_with_correct_emails_and_uacs(context, email_column)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

A support tool UI scenario was failing, when attempting to fill the allow email template on action rule form the `find_by_value` was failing for some reason. However, `find_by_id` works fine. Also the support tool UI tests were not consuming the collection exercise and survey updates they generate, which could pollute subsequent tests.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Changed broken `find_by_value` to `find_by_id`
- Consume survey and collection exercise updates which tests generate
- Some naming tense/grammar housekeeping

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the support tool UI `Create an Email Action Rule` scenario on `main` branch on a fresh database, you should be able to replicate the failure. Clear the database, check out this branch and run the scenario again, it should now pass every time.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/6ituaHFc/366-fix-support-tool-ui-test-creating-an-email-action-rule