### PR TITLE
Change page error id to alert

### DIFF
--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -80,6 +80,6 @@ def enter_no_uac(context):
 
 @step('an error section is displayed with href "{href_name}" is displayed with "{expected_text}"')
 def error_section_displayed(context, href_name, expected_text):
-    test_helper.assertEqual(context.browser.find_by_id('error-summary-title').text, 'There is a problem with this page')
+    test_helper.assertEqual(context.browser.find_by_id('alert').text, 'There is a problem with this page')
     error_text = context.browser.links.find_by_href(href_name).text
     test_helper.assertEqual(error_text, expected_text)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
Updating the design system in the RH UI caused the page error id to be changed to alert
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Changed the ID being checked for to alert
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the RH UI on the branch of the same name, run the ATs on this branch.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/FBJZ4TIC/305-rh-ui-session-not-saving-the-cookie-choices-made-by-the-respondent-1-day
# Screenshots (if appropriate):