### PR TITLE
Fail tests when messages remain on topics

### DIFF
--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -46,3 +46,4 @@ Feature: Test basic Support Tool Functionality
     And I click the upload sample file button with file "sis_survey_link.csv"
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"
+    And A UAC_UPDATE event is sent for the record in the sample file

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -46,4 +46,4 @@ Feature: Test basic Support Tool Functionality
     And I click the upload sample file button with file "sis_survey_link.csv"
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"
-    And A UAC_UPDATE event is sent for the record in the sample file
+    And UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -60,7 +60,6 @@ def before_scenario(context, scenario):
 
 
 def after_all(_context):
-    purge_outbound_topics()
     move_fulfilment_triggers_harmlessly_massively_into_the_future()
 
 
@@ -75,6 +74,9 @@ def after_scenario(context, scenario):
 
     if 'UI' in context.tags:
         context.browser.quit()
+
+    if purge_outbound_topics():
+        test_helper.fail('There are left over messages on some topics that were not expected.')
 
 
 def _record_and_remove_any_unexpected_bad_messages(unexpected_bad_messages):

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -75,8 +75,10 @@ def after_scenario(context, scenario):
     if 'UI' in context.tags:
         context.browser.quit()
 
-    if purge_outbound_topics():
-        test_helper.fail('There are left over messages on some topics that were not expected.')
+    leftover_mmessages = purge_outbound_topics()
+    if leftover_mmessages:
+        test_helper.fail(f'There are left over messages on the following subscriptions: {leftover_mmessages}, see logs '
+                         f'above for details.')
 
 
 def _record_and_remove_any_unexpected_bad_messages(unexpected_bad_messages):

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -181,10 +181,3 @@ def case_updated_emitted_with_correct_sensitve_data(context):
                             f'The emitted case, {emitted_case} does not match the case {context.case_id}')
     test_helper.assertEqual(emitted_case["sampleSensitive"]['PHONE_NUMBER'], "REDACTED",
                             "Expected emitted_case['sampleSensitive']['PHONE_NUMBER'] to equal 'REDACTED'")
-
-
-@step("A UAC_UPDATE event is sent for the record in the sample file")
-def step_impl(context):
-    emitted_uac = get_emitted_uac_update(context.correlation_id, context.originating_user)
-    test_helper.assertEqual(emitted_uac['caseId'], context.emitted_cases[0]['caseId'],
-                            f'The UAC_UPDATE message case ID must match the first case ID, emitted_uac {emitted_uac}')

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -181,3 +181,10 @@ def case_updated_emitted_with_correct_sensitve_data(context):
                             f'The emitted case, {emitted_case} does not match the case {context.case_id}')
     test_helper.assertEqual(emitted_case["sampleSensitive"]['PHONE_NUMBER'], "REDACTED",
                             "Expected emitted_case['sampleSensitive']['PHONE_NUMBER'] to equal 'REDACTED'")
+
+
+@step("A UAC_UPDATE event is sent for the record in the sample file")
+def step_impl(context):
+    emitted_uac = get_emitted_uac_update(context.correlation_id, context.originating_user)
+    test_helper.assertEqual(emitted_uac['caseId'], context.emitted_cases[0]['caseId'],
+                            f'The UAC_UPDATE message case ID must match the first case ID, emitted_uac {emitted_uac}')

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -67,7 +67,7 @@ def click_create_collex_button(context):
     collection_instrument_selection_rules = [
         {
             "priority": 100,
-            "spelExpression": "caze.sample['POSTCODE'] == 'NW16 FNK'",
+            "spelExpression": "caze.sample['schoolId'] == '123'",
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         },
         {

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -5,4 +5,4 @@ Feature: Telephone capture
     When there is a request for telephone capture of a case
     Then a UAC and QID with questionnaire type "01" type are generated and returned
     And the events logged against the case are ["NEW_CASE","TELEPHONE_CAPTURE"]
-    And A UAC_UPDATE event is sent for the record in the sample file
+    And UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -5,3 +5,4 @@ Feature: Telephone capture
     When there is a request for telephone capture of a case
     Then a UAC and QID with questionnaire type "01" type are generated and returned
     And the events logged against the case are ["NEW_CASE","TELEPHONE_CAPTURE"]
+    And A UAC_UPDATE event is sent for the record in the sample file


### PR DESCRIPTION
# Motivation and Context
The tests sometimes have message left over on topics that should not be there and can cause issues for future tests

# What has changed
made tests fail if there are leftover messages on any topics

# How to test?
I tested by making a dummy scenario that just put a message on one of the topics, and checked that the test failed in the after_scenario hook
