### PR TITLE
318 Undo Travis pipenv pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - pip uninstall -y numpy  # Remove the vulnerable Numpy which Travis provides
 
 install:
-  - pip install -U pipenv==v2022.8.5
+  - pip install -U pipenv
   - pipenv install --dev --deploy
 
 script:


### PR DESCRIPTION
# Motivation and Context
Travis pipenv was pinned because of a bug, unpin it now it is fixed

# What has changed
- Undo Travis pipenv pin

# How to test?
Travis will run

# Links
https://trello.com/c/9v3Ro8ED/318-revert-travis-ci-pipenv-install-back-to-latest-version-once-theres-a-fix-3