### PR TITLE
enable gke auth plugin in ATs task

### DIFF
--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -26,7 +26,7 @@ run:
       cat >~/gcloud-service-key.json <<EOL
       $SERVICE_ACCOUNT_JSON
       EOL
-
+      export USE_GKE_GCLOUD_AUTH_PLUGIN=True
       # Use gcloud service account to configure kubectl
       gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
       gcloud container clusters get-credentials ${KUBERNETES_CLUSTER} --zone europe-west2 --project ${GCP_PROJECT_NAME}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
To stop the gke auth plugin warnings we need to export the env var
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- export gke auth plugin env var in ATs task
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run ATs in concourse with this branch and you shouldn't see errors
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/xjeC3aLn/)