### PR TITLE
make RH UI check UAC exists in Firestore

### DIFF
--- a/acceptance_tests/features/RH_UI.feature
+++ b/acceptance_tests/features/RH_UI.feature
@@ -16,6 +16,7 @@ Feature: Testing the "enter a UAC" functionality of RH UI
     And UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the SMS fulfilment UAC
     And we retrieve the UAC and QID from the SMS fulfilment to use for launching in RH
+    And check UAC is in firestore via eqLaunched endpoint
     When the UAC entry page is displayed
     And the user enters a valid UAC
     Then they are redirected to EQ with the correct token

--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -1,6 +1,5 @@
 Feature: Handle EQ launch events
 
-
   Scenario: EQ launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
     And an export file template has been created with template ["__uac__"]

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -54,8 +54,8 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 @step(
     'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
     ' {expected_value:boolean}')
-def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step(context, active,
-                                                                         field_to_test, expected_value):
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step(context, active, field_to_test,
+                                                                              expected_value):
     check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context.emitted_cases, context.correlation_id,
                                                                          active, field_to_test, expected_value)
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -56,8 +56,9 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
     ' {expected_value:boolean}')
 def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step(context, active, field_to_test,
                                                                               expected_value):
-    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context.emitted_cases, context.correlation_id,
-                                                                         active, field_to_test, expected_value)
+    context.emitted_uacs = check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(
+        context.emitted_cases, context.correlation_id,
+        active, field_to_test, expected_value)
 
 
 @step("{expected_count:d} UAC_UPDATE messages are emitted with active set to {active:boolean}")

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -2,7 +2,8 @@ from behave import step
 
 from acceptance_tests.utilities.event_helper import check_invalid_case_reason_matches_on_event, \
     get_emitted_case_events_by_type, get_emitted_case_update, get_emitted_cases, get_emitted_uac_update, \
-    get_uac_update_events
+    get_uac_update_events, _check_uacs_updated_match_cases, _check_new_uacs_are_as_expected, \
+    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value
 from acceptance_tests.utilities.test_case_helper import test_helper
 
 
@@ -53,12 +54,10 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
 @step(
     'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
     ' {expected_value:boolean}')
-def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context, active,
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step(context, active,
                                                                          field_to_test, expected_value):
-    context.emitted_uacs = get_uac_update_events(len(context.emitted_cases), context.correlation_id,
-                                                 None)
-    _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
-    _check_new_uacs_are_as_expected(context.emitted_uacs, active, field_to_test, expected_value)
+    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context.emitted_cases, context.correlation_id,
+                                                                         active, field_to_test, expected_value)
 
 
 @step("{expected_count:d} UAC_UPDATE messages are emitted with active set to {active:boolean}")
@@ -79,26 +78,6 @@ def check_case_updated_emitted_for_new_case(context):
     emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user)
     test_helper.assertEqual(emitted_case['caseId'], context.case_id,
                             f'The emitted case, {emitted_case} does not match the case {context.case_id}')
-
-
-def _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test=None, expected_value=None):
-    for uac in emitted_uacs:
-        test_helper.assertEqual(uac['active'], active, f"UAC {uac} active status doesn't equal expected {active}")
-
-        if field_to_test:
-            test_helper.assertEqual(uac[field_to_test], expected_value,
-                                    f"UAC {uac} field {field_to_test} doesn't equal expected {expected_value}")
-
-
-def _check_uacs_updated_match_cases(uac_update_events, cases):
-    test_helper.assertSetEqual(set(uac['caseId'] for uac in uac_update_events),
-                               set(case['caseId'] for case in cases),
-                               'The UAC updated events should be linked to the given set of case IDs')
-
-    test_helper.assertEqual(len(uac_update_events), len(cases),
-                            'There should be one and only one UAC updated event for each given case ID,'
-                            f'uac_update_events: {uac_update_events} '
-                            f'cases {cases}')
 
 
 @step("a CASE_UPDATE message is emitted for each bulk updated case with expected refusal type")

--- a/acceptance_tests/features/steps/rh_endpoint.py
+++ b/acceptance_tests/features/steps/rh_endpoint.py
@@ -15,4 +15,3 @@ def check_launch_redirect_and_token(context):
                                                         context.emitted_cases[0]['caseId'],
                                                         context.collex_id)
     context.correlation_id = eq_claims['tx_id']
-

--- a/acceptance_tests/features/steps/rh_endpoint.py
+++ b/acceptance_tests/features/steps/rh_endpoint.py
@@ -1,10 +1,6 @@
 from behave import step
-from requests import Response
-from urllib.parse import parse_qs, urlparse
-
 from acceptance_tests.utilities import rh_endpoint_client
-from acceptance_tests.utilities.jwe_helper import decrypt_claims_token_and_check_contents
-from acceptance_tests.utilities.test_case_helper import test_helper
+from acceptance_tests.utilities.rh_helper import check_launch_redirect_and_get_eq_claims
 
 
 @step('the respondent home UI launch endpoint is called with the UAC')
@@ -14,21 +10,9 @@ def post_rh_launch_endpoint(context):
 
 @step('it redirects to a launch URL with a launch claims token')
 def check_launch_redirect_and_token(context):
-    response: Response = context.rh_launch_endpoint_response
-    test_helper.assertTrue(response.is_redirect, 'Expected RH response to redirect to EQ launch')
-
-    launch_url = response.next.url
-    query_strings = parse_qs(urlparse(launch_url).query)
-
-    test_helper.assertIn('token', query_strings,
-                         f'Expected to find launch token in launch URL, actual launch url: {launch_url}')
-    test_helper.assertEqual(
-        len(query_strings['token']), 1,
-        f'Expected to find exactly 1 token in the launch URL query stings, actual launch url: {launch_url}')
-
-    eq_claims = decrypt_claims_token_and_check_contents(context.rh_launch_qid,
+    eq_claims = check_launch_redirect_and_get_eq_claims(context.rh_launch_endpoint_response,
+                                                        context.rh_launch_qid,
                                                         context.emitted_cases[0]['caseId'],
-                                                        context.collex_id,
-                                                        query_strings['token'][0])
-
+                                                        context.collex_id)
     context.correlation_id = eq_claims['tx_id']
+

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -2,9 +2,6 @@ from urllib.parse import urlparse, parse_qs
 
 from behave import step
 
-from acceptance_tests.features.steps.events_emitted import \
-    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step
-from acceptance_tests.features.steps.rh_endpoint import check_launch_redirect_and_token
 from acceptance_tests.utilities import rh_endpoint_client
 from acceptance_tests.utilities.event_helper import check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value
 from acceptance_tests.utilities.jwe_helper import decrypt_claims_token_and_check_contents

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -1,7 +1,12 @@
 from urllib.parse import urlparse, parse_qs
 
 from behave import step
+from tenacity import wait_fixed, stop_after_delay, retry
 
+from acceptance_tests.features.steps.events_emitted import \
+    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value
+from acceptance_tests.features.steps.rh_endpoint import check_launch_redirect_and_token
+from acceptance_tests.utilities import rh_endpoint_client
 from acceptance_tests.utilities.jwe_helper import decrypt_claims_token_and_check_contents
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -83,3 +88,18 @@ def error_section_displayed(context, href_name, expected_text):
     test_helper.assertEqual(context.browser.find_by_id('alert').text, 'There is a problem with this page')
     error_text = context.browser.links.find_by_href(href_name).text
     test_helper.assertEqual(error_text, expected_text)
+
+
+@retry(wait=wait_fixed(1), stop=stop_after_delay(30))
+def retry_launch_eq(rh_launch_uac):
+    rh_launch_endpoint_response = rh_endpoint_client.post_to_launch_endpoint(rh_launch_uac)
+    rh_launch_endpoint_response.raise_for_status()
+
+    return rh_launch_endpoint_response
+
+
+@step("check UAC is in firestore via eqLaunched endpoint")
+def check_uac_in_firestore(context):
+    context.rh_launch_endpoint_response = retry_launch_eq(context.rh_launch_uac)
+    check_launch_redirect_and_token(context)
+    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context, True, "eqLaunched", True)

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -103,3 +103,30 @@ def check_invalid_case_reason_matches_on_event(event_id, expected_reason):
 
         test_helper.assertEqual(result[0]['invalidCase']['reason'], expected_reason,
                                 "The invalid case reason doesn't matched expected")
+
+
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted_cases, correlation_id,
+                                                                         active, field_to_test, expected_value):
+    emitted_uacs = get_uac_update_events(len(emitted_cases), correlation_id, None)
+    _check_uacs_updated_match_cases(emitted_uacs, emitted_cases)
+    _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test, expected_value)
+
+
+def _check_uacs_updated_match_cases(uac_update_events, cases):
+    test_helper.assertSetEqual(set(uac['caseId'] for uac in uac_update_events),
+                               set(case['caseId'] for case in cases),
+                               'The UAC updated events should be linked to the given set of case IDs')
+
+    test_helper.assertEqual(len(uac_update_events), len(cases),
+                            'There should be one and only one UAC updated event for each given case ID,'
+                            f'uac_update_events: {uac_update_events} '
+                            f'cases {cases}')
+
+
+def _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test=None, expected_value=None):
+    for uac in emitted_uacs:
+        test_helper.assertEqual(uac['active'], active, f"UAC {uac} active status doesn't equal expected {active}")
+
+        if field_to_test:
+            test_helper.assertEqual(uac[field_to_test], expected_value,
+                                    f"UAC {uac} field {field_to_test} doesn't equal expected {expected_value}")

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -111,6 +111,8 @@ def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted
     _check_uacs_updated_match_cases(emitted_uacs, emitted_cases)
     _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test, expected_value)
 
+    return emitted_uacs
+
 
 def _check_uacs_updated_match_cases(uac_update_events, cases):
     test_helper.assertSetEqual(set(uac['caseId'] for uac in uac_update_events),

--- a/acceptance_tests/utilities/rh_endpoint_client.py
+++ b/acceptance_tests/utilities/rh_endpoint_client.py
@@ -12,7 +12,7 @@ def is_exception_http_unauthorized(ex: BaseException) -> bool:
 
 
 # Retry on 401 errors as the UAC may not have been ingested into RH before the first attempt
-@retry(retry=retry_if_exception(is_exception_http_unauthorized), wait=wait_fixed(1), stop=stop_after_delay(10),
+@retry(retry=retry_if_exception(is_exception_http_unauthorized), wait=wait_fixed(1), stop=stop_after_delay(30),
        reraise=True)
 def post_to_launch_endpoint(uac: str) -> requests.Response:
     response = requests.post(f'{Config.RH_UI_URL}en/start/', data={'uac': uac}, allow_redirects=False)

--- a/acceptance_tests/utilities/rh_helper.py
+++ b/acceptance_tests/utilities/rh_helper.py
@@ -1,0 +1,24 @@
+from requests import Response
+
+from acceptance_tests.utilities.jwe_helper import decrypt_claims_token_and_check_contents
+from acceptance_tests.utilities.test_case_helper import test_helper
+from urllib.parse import parse_qs, urlparse
+
+
+def check_launch_redirect_and_get_eq_claims(rh_launch_endpoint_response, rh_launch_qid, case_id, collex_id):
+    response: Response = rh_launch_endpoint_response
+    test_helper.assertTrue(response.is_redirect, 'Expected RH response to redirect to EQ launch')
+
+    launch_url = response.next.url
+    query_strings = parse_qs(urlparse(launch_url).query)
+
+    test_helper.assertIn('token', query_strings,
+                         f'Expected to find launch token in launch URL, actual launch url: {launch_url}')
+    test_helper.assertEqual(
+        len(query_strings['token']), 1,
+        f'Expected to find exactly 1 token in the launch URL query stings, actual launch url: {launch_url}')
+
+    return decrypt_claims_token_and_check_contents(rh_launch_qid,
+                                                   case_id,
+                                                   collex_id,
+                                                   query_strings['token'][0])


### PR DESCRIPTION
# Motivation and Context
Is a cold pubsub firestore causing early tests like RH-UI to occasionally fail in CI?  

# What has changed
calls the eqlaunched endpoint directly with the UAC in order to see if the UAC is in Firestore, then clear up any UAC_UPDATES

# How to test?
make test

# Links
https://trello.com/c/LZVpHnqu/425-fix-rh-ui-ci-tests