### PR TITLE
questionnaire id becomes qid

### DIFF
--- a/acceptance_tests/features/exception_manager.feature
+++ b/acceptance_tests/features/exception_manager.feature
@@ -8,7 +8,7 @@ Feature: Check exception manager is called for every topic and handles them as e
   @regression
   Scenario: Deactivate unknown UAC turns up in exception manager
     When a bad deactivate uac message is put on the topic
-    Then a bad message appears in exception manager with exception message containing "Questionnaire Id '123456789' not found!"
+    Then a bad message appears in exception manager with exception message containing "qid '123456789' not found!"
     And each bad msg can be successfully quarantined
 
   @regression
@@ -20,7 +20,7 @@ Feature: Check exception manager is called for every topic and handles them as e
   @regression
   Scenario: Bad receipt message turns up in exception manager
     When a bad receipt message is put on the topic
-    Then a bad message appears in exception manager with exception message containing "Questionnaire Id '987654321' not found!"
+    Then a bad message appears in exception manager with exception message containing "qid '987654321' not found!"
     And each bad msg can be successfully quarantined
 
   @regression
@@ -32,7 +32,7 @@ Feature: Check exception manager is called for every topic and handles them as e
   @regression
   Scenario: Bad respondent authenticated message turns up in exception manager
     When a bad respondent authenticated event is put on the topic
-    Then a bad message appears in exception manager with exception message containing "Questionnaire Id '666' not found!"
+    Then a bad message appears in exception manager with exception message containing "qid '666' not found!"
     And each bad msg can be successfully quarantined
 
   @regression
@@ -50,7 +50,7 @@ Feature: Check exception manager is called for every topic and handles them as e
   @regression
   Scenario: Bad EQ launched message turns up in exception manager
     When a bad EQ launched event is put on the topic
-    Then a bad message appears in exception manager with exception message containing "Questionnaire Id '555555' not found!"
+    Then a bad message appears in exception manager with exception message containing "qid '555555' not found!"
     And each bad msg can be successfully quarantined
 
   @regression

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -37,7 +37,7 @@ def a_bad_receipt_message_is_put_on_the_topic(context):
 def _send_sdx_receipt(qid):
     message = json.dumps({
         "data": {
-            "questionnaire_id": qid,
+            "qid": qid,
             "source": "SRM"
         }}
     )

--- a/acceptance_tests/utilities/jwe_helper.py
+++ b/acceptance_tests/utilities/jwe_helper.py
@@ -22,11 +22,11 @@ def decrypt_signed_jwe(signed_jwe: str) -> Mapping:
 def decrypt_claims_token_and_check_contents(rh_launch_qid: str, case_id: str, collex_id: str, token: str) \
         -> Mapping:
     eq_claims = decrypt_signed_jwe(token)
-    test_helper.assertEqual(eq_claims['survey_metadata']['data']['questionnaire_id'], rh_launch_qid,
+    test_helper.assertEqual(eq_claims['survey_metadata']['data']['qid'], rh_launch_qid,
                             f'Expected to find the correct QID in the claims payload, actual payload: {eq_claims}')
 
-    test_helper.assertEqual(eq_claims['survey_metadata']["receipting_keys"], ['questionnaire_id', 'source'],
-                            f'Expected to find the questionnaire_id as receipting key in claims payload, '
+    test_helper.assertEqual(eq_claims['survey_metadata']["receipting_keys"], ['qid', 'source'],
+                            f'Expected to find the qid as receipting key in claims payload, '
                             f'actual payload: {eq_claims}')
     test_helper.assertEqual(eq_claims['survey_metadata']['data']['source'], "SRM",
                             f'Expected to find the correct source in the claims payload, actual payload: {eq_claims}')


### PR DESCRIPTION
# Motivation and Context
QID is the new kid on the block, down with questionnaire id

# What has changed
renaming

# How to test?
With others from ticket

# Links
https://trello.com/b/VS0ZyRmj/srm