### PR TITLE
658 Use supplier config in the AT pod

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -38,7 +38,7 @@ spec:
       mountPath: "/home/acceptancetests/postgresql"
       readOnly: true
     - name: export-file-destinations
-      mountPath: "/home/export-file-service/config"
+      mountPath: "/home/acceptancetests/destination_config"
       readOnly: true
     env:
     - name: DB_USERNAME
@@ -79,7 +79,7 @@ spec:
           name: project-config
           key: project-name
     - name: SUPPLIER_CONFIG_JSON_PATH
-      value: "/home/export-file-service/config/export-file-destination-config.json"
+      value: "/home/acceptancetests/destination_config/export-file-destination-config.json"
     - name: SUPPORT_TOOL_HOST
       value: "support-tool"
     - name: SUPPORT_TOOL_PORT

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -37,6 +37,9 @@ spec:
     - name: case-cloud-sql-certs
       mountPath: "/home/acceptancetests/postgresql"
       readOnly: true
+    - name: export-file-destinations
+      mountPath: "/home/export-file-service/config"
+      readOnly: true
     env:
     - name: DB_USERNAME
       valueFrom:
@@ -76,7 +79,7 @@ spec:
           name: project-config
           key: project-name
     - name: SUPPLIER_CONFIG_JSON_PATH
-      value: "/home/acceptancetests/dummy_export_file_destination_config.json"
+      value: "/home/export-file-service/config/export-file-destination-config.json"
     - name: SUPPORT_TOOL_HOST
       value: "support-tool"
     - name: SUPPORT_TOOL_PORT
@@ -113,6 +116,13 @@ spec:
     - name: EQ_FLUSH_STUB_URL
       value: "http://eq-stub"
   volumes:
+  - name: export-file-destinations
+    secret:
+      secretName: export-file-destinations
+      defaultMode: 0400
+      items:
+        - key: config
+          path: "export-file-destination-config.json"
   - name: case-cloud-sql-certs
     secret:
       secretName: cloud-sql-certs


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

The ATs were using their own copy of the supplier config, this is fine locally but in K8s they should pick up the secret from the cluster. They will still only run if a `supplier_a` exists, but the destination path can be read out of the config, instead of the local dummy copy.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Use cluster supplier config in AT pod

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the pod manifest is correct

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/p20RGw6C/658-create-printfile-nifi-cloud-function-8-ah-kp