### PR TITLE
835 Check eq claims response_expires_at

### DIFF
--- a/acceptance_tests/utilities/jwe_helper.py
+++ b/acceptance_tests/utilities/jwe_helper.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 from typing import Mapping
 from jwcrypto import jwe, jws
@@ -39,5 +40,9 @@ def decrypt_claims_token_and_check_contents(rh_launch_qid: str, case_id: str, co
 
     test_helper.assertEqual(eq_claims["language_code"], language_code,
                             f'Expected correct language code: actual payload: {eq_claims}')
+
+    test_helper.assertGreater(datetime.datetime.fromisoformat(eq_claims["response_expires_at"]),
+                              datetime.datetime.utcnow().astimezone(datetime.UTC),
+                              'Expected the response_expires_at to be set in the future')
 
     return eq_claims

--- a/acceptance_tests/utilities/rh_helper.py
+++ b/acceptance_tests/utilities/rh_helper.py
@@ -5,12 +5,14 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from urllib.parse import parse_qs, urlparse
 
 
-def check_launch_redirect_and_get_eq_claims(rh_launch_endpoint_response, rh_launch_qid, case_id, collex_id,
-                                            language_code):
-    response: Response = rh_launch_endpoint_response
-    test_helper.assertTrue(response.is_redirect, 'Expected RH response to redirect to EQ launch')
+def check_launch_redirect_and_get_eq_claims(rh_launch_endpoint_response: Response,
+                                            rh_launch_qid: str,
+                                            case_id: str,
+                                            collex_id: str,
+                                            language_code: str):
+    test_helper.assertTrue(rh_launch_endpoint_response.is_redirect, 'Expected RH response to redirect to EQ launch')
 
-    launch_url = response.next.url
+    launch_url = rh_launch_endpoint_response.next.url
     query_strings = parse_qs(urlparse(launch_url).query)
 
     test_helper.assertIn('token', query_strings,


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
eQ seems to delete partials overnight if the optional `response_expires_at` field is not set on the launch claims. As a temporary fix, we will always set this to be a year in the future to avoid partials being deleted.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Check `response_expires_at` in eQ launch claims

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run linked RH service branch, run ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/GSSoMobL/835-eq-is-purging-partials-as-they-are-not-receiving-responseexpiredat-variable-as-part-of-the-jwt-token
