### PR TITLE
502 Ignore messages from before scenario

### DIFF
--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -46,4 +46,4 @@ Feature: Test basic Support Tool Functionality
     And I click the upload sample file button with file "sis_survey_link.csv"
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"
-    And UAC_UPDATE messages are emitted with active set to true
+    And the correct number of UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from distutils.util import strtobool
 
 import requests
@@ -44,7 +44,7 @@ def before_scenario(context, scenario):
     purge_outbound_topics()
     move_fulfilment_triggers_harmlessly_massively_into_the_future()
 
-    context.test_start_utc_datetime = datetime.utcnow()
+    context.test_start_utc_datetime = datetime.utcnow().replace(tzinfo=timezone.utc)
     context.correlation_id = None
     context.originating_user = None
     context.sent_messages = []

--- a/acceptance_tests/features/sdx_receipt.feature
+++ b/acceptance_tests/features/sdx_receipt.feature
@@ -8,5 +8,5 @@ Feature: A case can be receipted with an event from sdx
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the email fulfilment UAC
     When a receipt message is published to the sdx pubsub receipting topic
-    Then UAC_UPDATE message is emitted with active set to false and "receiptReceived" is true
+    Then UAC_UPDATE messages are emitted for the correct cases with active set to false and "receiptReceived" is true
     And the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT","RECEIPT"]

--- a/acceptance_tests/features/steps/action_rule.py
+++ b/acceptance_tests/features/steps/action_rule.py
@@ -6,27 +6,27 @@ from acceptance_tests.utilities.action_rule_helper import create_export_file_act
 
 @step('an export file action rule has been created with classifiers "{classifiers}"')
 def create_export_file_action_rule_with_classifiers(context, classifiers):
-    create_export_file_action_rule(context.collex_id, classifiers, context.pack_code)
+    context.correlation_id = create_export_file_action_rule(context.collex_id, classifiers, context.pack_code)
 
 
 @step('an export file action rule has been created')
 def create_export_file_action_rule_no_classifiers(context):
-    create_export_file_action_rule(context.collex_id, '', context.pack_code)
+    context.correlation_id = create_export_file_action_rule(context.collex_id, '', context.pack_code)
 
 
 @step('a deactivate uac action rule has been created')
 def create_deactivate_uac_action_rule(context):
-    setup_deactivate_uac_action_rule(context.collex_id)
+    context.correlation_id = setup_deactivate_uac_action_rule(context.collex_id)
 
 
 @step("a SMS action rule has been created")
 def create_sms_action_rule(context):
-    setup_sms_action_rule(context.collex_id, context.pack_code)
+    context.correlation_id = setup_sms_action_rule(context.collex_id, context.pack_code)
 
 
 @step("an email action rule has been created")
 def create_email_action_rule(context):
-    setup_email_action_rule(context.collex_id, context.pack_code)
+    context.correlation_id = setup_email_action_rule(context.collex_id, context.pack_code)
 
 
 @step("an EQ flush action rule has been created")

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -6,7 +6,7 @@ from behave import step
 
 from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
-from acceptance_tests.utilities.event_helper import get_exactly_one_emitted_survey_update
+from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_email_fulfilment_response
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -23,7 +23,7 @@ def authorise_sms_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
+    survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)
 
     allowed_email_fulfilments = survey_update_event['allowedEmailFulfilments']
     test_helper.assertEqual(len(allowed_email_fulfilments), 1,

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -23,7 +23,7 @@ def authorise_sms_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update()
+    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
 
     allowed_email_fulfilments = survey_update_event['allowedEmailFulfilments']
     test_helper.assertEqual(len(allowed_email_fulfilments), 1,

--- a/acceptance_tests/features/steps/eq_flush.py
+++ b/acceptance_tests/features/steps/eq_flush.py
@@ -20,7 +20,7 @@ def check_eq_flush_cloud_task_message(context):
         return True, ''
 
     cloud_task_message = get_matching_pubsub_message_acking_others(Config.PUBSUB_CLOUD_TASK_QUEUE_AT_SUBSCRIPTION,
-                                                                   _message_matcher)
+                                                                   _message_matcher, context.test_start_utc_datetime)
 
     test_helper.assertIsNotNone(cloud_task_message['payload'].get('transactionId'),
                                 'Expected EQ flush cloud task payload to have a transaction ID')

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -3,7 +3,8 @@ from behave import step
 from acceptance_tests.utilities.event_helper import check_invalid_case_reason_matches_on_event, \
     get_logged_case_events_by_type, get_emitted_case_update, get_emitted_cases, get_emitted_uac_update, \
     get_uac_update_events, _check_uacs_updated_match_cases, _check_new_uacs_are_as_expected, \
-    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value
+    check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value, get_number_of_uac_update_events, \
+    check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_value
 from acceptance_tests.utilities.test_case_helper import test_helper
 
 
@@ -54,15 +55,36 @@ def check_uac_update_msgs_emitted_with_qid_active(context, active):
                                     expected_value=context.expected_collection_instrument_url)
 
 
-@step(
-    'UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
-    ' {expected_value:boolean}')
+@step('the correct number of UAC_UPDATE messages are emitted with active set to {active:boolean}')
+def check_uac_updated_messages_by_number_with_qid_active(context, active):
+    context.emitted_uacs = get_number_of_uac_update_events(len(context.emitted_cases), context.test_start_utc_datetime)
+    _check_uacs_updated_match_cases(context.emitted_uacs, context.emitted_cases)
+
+    _check_new_uacs_are_as_expected(emitted_uacs=context.emitted_uacs, active=active,
+                                    field_to_test='collectionInstrumentUrl',
+                                    expected_value=context.expected_collection_instrument_url)
+
+
+@step('UAC_UPDATE message is emitted with active set to {active:boolean} and "{field_to_test}" is'
+      ' {expected_value:boolean}')
 def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value_step(context, active, field_to_test,
                                                                               expected_value):
     context.emitted_uacs = check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(
         context.emitted_cases,
         context.correlation_id,
         active, field_to_test,
+        expected_value,
+        context.test_start_utc_datetime)
+
+
+@step('UAC_UPDATE messages are emitted for the correct cases with active set to {active:boolean}'
+      ' and "{bool_field_to_test}" is {expected_value:boolean}')
+def check_uac_update_for_qid_with_active_and_bool_field(context, active: bool, bool_field_to_test: str,
+                                                        expected_value: bool):
+    context.emitted_uacs = check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_value(
+        context.emitted_cases,
+        active,
+        bool_field_to_test,
         expected_value,
         context.test_start_utc_datetime)
 

--- a/acceptance_tests/features/steps/events_emitted.py
+++ b/acceptance_tests/features/steps/events_emitted.py
@@ -1,7 +1,8 @@
 from behave import step
 
 from acceptance_tests.utilities.event_helper import check_invalid_case_reason_matches_on_event, \
-    get_logged_case_events_by_type, get_emitted_case_update, get_emitted_cases, get_emitted_uac_update, \
+    get_logged_case_events_by_type, get_emitted_case_update_by_correlation_id, \
+    get_emitted_cases, get_emitted_uac_update, \
     get_uac_update_events, _check_uacs_updated_match_cases, _check_new_uacs_are_as_expected, \
     check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value, get_number_of_uac_update_events, \
     check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_value
@@ -20,8 +21,8 @@ def uac_update_msg_emitted(context):
 
 @step('a CASE_UPDATE message is emitted where "{case_field}" is "{expected_field_value}"')
 def case_update_msg_sent_with_values(context, case_field, expected_field_value):
-    emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user,
-                                           context.test_start_utc_datetime)
+    emitted_case = get_emitted_case_update_by_correlation_id(context.correlation_id, context.originating_user,
+                                                             context.test_start_utc_datetime)
 
     test_helper.assertEqual(emitted_case['caseId'], context.emitted_cases[0]['caseId'],
                             'The updated case is expected to be the first stored emitted case,'
@@ -32,8 +33,8 @@ def case_update_msg_sent_with_values(context, case_field, expected_field_value):
 
 @step('a CASE_UPDATE message is emitted where {new_values:json} are the updated values')
 def case_update_msg_sent_with_multiple_values(context, new_values):
-    emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user,
-                                           context.test_start_utc_datetime)
+    emitted_case = get_emitted_case_update_by_correlation_id(context.correlation_id, context.originating_user,
+                                                             context.test_start_utc_datetime)
 
     test_helper.assertEqual(emitted_case['caseId'], context.emitted_cases[0]['caseId'],
                             'The updated case is expected to be the first stored emitted case,'
@@ -105,8 +106,8 @@ def check_expected_number_of_uac_update_msgs_emitted(context, expected_count, ac
 @step("a CASE_UPDATED message is emitted for the case")
 @step("a CASE_UPDATED message is emitted for the new case")
 def check_case_updated_emitted_for_new_case(context):
-    emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user,
-                                           context.test_start_utc_datetime)
+    emitted_case = get_emitted_case_update_by_correlation_id(context.correlation_id, context.originating_user,
+                                                             context.test_start_utc_datetime)
     test_helper.assertEqual(emitted_case['caseId'], context.case_id,
                             f'The emitted case, {emitted_case} does not match the case {context.case_id}')
 
@@ -173,7 +174,7 @@ def get_bulk_data_row_from_case_id_or_fail(bulk_data, case_id):
 
 
 @step("a CASE_UPDATE message is emitted for each case with sensitive data redacted")
-def case_update_message_emited_for_every_case_with_sensitive_data_redacted(context):
+def case_update_message_emitted_for_every_case_with_sensitive_data_redacted(context):
     emitted_updated_cases = get_emitted_cases(len(context.bulk_sensitive_update), context.test_start_utc_datetime)
 
     for emitted_case in emitted_updated_cases:
@@ -185,9 +186,9 @@ def case_update_message_emited_for_every_case_with_sensitive_data_redacted(conte
 
 
 @step("a CASE_UPDATED message is emitted for the case with correct sensitive data")
-def case_updated_emitted_with_correct_sensitve_data(context):
-    emitted_case = get_emitted_case_update(context.correlation_id, context.originating_user,
-                                           context.test_start_utc_datetime)
+def case_updated_emitted_with_correct_sensitive_data(context):
+    emitted_case = get_emitted_case_update_by_correlation_id(context.correlation_id, context.originating_user,
+                                                             context.test_start_utc_datetime)
     test_helper.assertEqual(emitted_case['caseId'], context.case_id,
                             f'The emitted case, {emitted_case} does not match the case {context.case_id}')
     test_helper.assertEqual(emitted_case["sampleSensitive"]['PHONE_NUMBER'], "REDACTED",

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -1,6 +1,6 @@
 import csv
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
@@ -141,7 +141,7 @@ def check_export_file_matches_expected(actual_export_file, expected_export_file)
 
 def get_datetime_from_export_file_name(export_file_name: str, prefix: str, suffix: str) -> datetime:
     raw_datetime = export_file_name[len(prefix):-len(suffix)]  # Strip off the prefix and suffix
-    return datetime.strptime(raw_datetime, '%Y-%m-%dT%H-%M-%S')
+    return datetime.strptime(raw_datetime, '%Y-%m-%dT%H-%M-%S').replace(tzinfo=timezone.utc)
 
 
 def get_export_file_contents_local(after_datetime: datetime, pack_code: str, export_file_destination: str,

--- a/acceptance_tests/features/steps/nifi_notification.py
+++ b/acceptance_tests/features/steps/nifi_notification.py
@@ -12,6 +12,6 @@ def check_nifi_export_file_notification_message(context):
         return message['files'][0]['name'].startswith(f'internal_reprographics/print_services/{context.pack_code}'), \
             'Notification message file name prefix did not match the pack code'
 
-    get_matching_pubsub_message_acking_others(
-        subscription=Config.PUBSUB_NIFI_INTERNAL_PRINT_NOTIFICATION_SUBSCRIPTION,
-        message_matcher=_message_matcher)
+    get_matching_pubsub_message_acking_others(subscription=Config.PUBSUB_NIFI_INTERNAL_PRINT_NOTIFICATION_SUBSCRIPTION,
+                                              message_matcher=_message_matcher,
+                                              test_start_time=context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/nifi_notification.py
+++ b/acceptance_tests/features/steps/nifi_notification.py
@@ -9,8 +9,10 @@ from config import Config
 @step('a notification PubSub message is sent to NIFI with the correct export file details')
 def check_nifi_export_file_notification_message(context):
     def _match_message_file_name_prefix(message: Mapping) -> tuple[bool, str]:
-        return message['files'][0]['name'].startswith(f'internal_reprographics/print_services/{context.pack_code}'), \
-            'Notification message file name prefix did not match the pack code'
+        message_file_name = message['files'][0]['name']
+        expected_prefix = f'internal_reprographics/print_services/{context.pack_code}'
+        return message_file_name.startswith(expected_prefix), \
+            f'Notification message file "{message_file_name}" does not have the expected prefix "{expected_prefix}"'
 
     get_matching_pubsub_message_acking_others(subscription=Config.PUBSUB_NIFI_INTERNAL_PRINT_NOTIFICATION_SUBSCRIPTION,
                                               message_matcher=_match_message_file_name_prefix,

--- a/acceptance_tests/features/steps/nifi_notification.py
+++ b/acceptance_tests/features/steps/nifi_notification.py
@@ -8,10 +8,10 @@ from config import Config
 
 @step('a notification PubSub message is sent to NIFI with the correct export file details')
 def check_nifi_export_file_notification_message(context):
-    def _message_matcher(message: Mapping) -> tuple[bool, str]:
+    def _match_message_file_name_prefix(message: Mapping) -> tuple[bool, str]:
         return message['files'][0]['name'].startswith(f'internal_reprographics/print_services/{context.pack_code}'), \
             'Notification message file name prefix did not match the pack code'
 
     get_matching_pubsub_message_acking_others(subscription=Config.PUBSUB_NIFI_INTERNAL_PRINT_NOTIFICATION_SUBSCRIPTION,
-                                              message_matcher=_message_matcher,
+                                              message_matcher=_match_message_file_name_prefix,
                                               test_start_time=context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -6,7 +6,7 @@ import requests
 from behave import step
 
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
-from acceptance_tests.utilities.event_helper import get_exactly_one_emitted_survey_update
+from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -66,7 +66,7 @@ def authorise_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
+    survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)
 
     allowed_print_fulfilments = survey_update_event['allowedPrintFulfilments']
     test_helper.assertEqual(len(allowed_print_fulfilments), 1,

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -66,7 +66,7 @@ def authorise_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update()
+    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
 
     allowed_print_fulfilments = survey_update_event['allowedPrintFulfilments']
     test_helper.assertEqual(len(allowed_print_fulfilments), 1,

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -110,7 +110,8 @@ def check_uac_in_firestore(context, language_code):
                                                         language_code)
     context.correlation_id = eq_claims['tx_id']
     check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(context.emitted_cases, context.correlation_id,
-                                                                         True, "eqLaunched", True)
+                                                                         True, "eqLaunched", True,
+                                                                         context.test_start_utc_datetime)
 
 
 @step('an error section is headed "{error_section_header}" and href "{href_name}" is "{expected_text}"')

--- a/acceptance_tests/features/steps/sample_loading.py
+++ b/acceptance_tests/features/steps/sample_loading.py
@@ -18,8 +18,8 @@ from config import Config
 VALIDATION_RULES_PATH = Config.RESOURCE_FILE_PATH.joinpath('validation_rules')
 
 
-def get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns=[]):
-    emitted_cases = get_emitted_cases(len(sample_rows))
+def get_emitted_cases_and_check_against_sample(sample_rows, test_start_time, sensitive_columns=[]):
+    emitted_cases = get_emitted_cases(len(sample_rows), test_start_time)
     unmatched_sample_rows = sample_rows.copy()
     for emitted_case in emitted_cases:
         matched_row = None
@@ -66,7 +66,7 @@ def load_bom_sample_file_step(context, sample_file_name):
     for index in range(len(sample_rows)):
         sample_rows[index]['TLA'] = sample_rows[index].pop('\ufeffTLA')
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
     context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
     collection_instrument_selection_rules = [
         {
@@ -75,11 +75,12 @@ def load_bom_sample_file_step(context, sample_file_name):
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
 
 @step('sample file "{sample_file_name}" is loaded successfully')
@@ -93,7 +94,7 @@ def load_sample_with_survey_type(context, sample_file_name, survey_type):
     sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
 
     sample_definition_url = "http://" + survey_type + ".json"
-    context.survey_id = add_survey(sample_validation_rules, sample_definition_url)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime, sample_definition_url)
 
     context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
     collection_instrument_selection_rules = [
@@ -103,11 +104,12 @@ def load_sample_with_survey_type(context, sample_file_name, survey_type):
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
 
 @step('sample file "{sample_file_name}" is loaded successfully with complex case CI selection rules')
@@ -115,7 +117,7 @@ def load_sample_file_with_complex_case_ci_rules_step(context, sample_file_name):
     sample_file_path = Config.SAMPLE_FILES_PATH.joinpath(sample_file_name)
     sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
 
     context.expected_collection_instrument_url = "http://test-eq.com/complex-schema"
     collection_instrument_selection_rules = [
@@ -130,11 +132,12 @@ def load_sample_file_with_complex_case_ci_rules_step(context, sample_file_name):
             "collectionInstrumentUrl": "this URL should not be chosen. If it is, the test is a failure"
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
 
 @step('sample file "{sample_file_name}" is loaded successfully with complex UAC CI selection rules')
@@ -142,7 +145,7 @@ def load_sample_file_with_complex_uac_ci_rules_step(context, sample_file_name):
     sample_file_path = Config.SAMPLE_FILES_PATH.joinpath(sample_file_name)
     sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path)
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
 
     context.expected_collection_instrument_url = "http://test-eq.com/super-complex-schema"
     collection_instrument_selection_rules = [
@@ -162,11 +165,12 @@ def load_sample_file_with_complex_uac_ci_rules_step(context, sample_file_name):
             "collectionInstrumentUrl": "this URL should not be chosen. If it is, the test is a failure"
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
 
 @step('the sample file "{sample_file_name}"'
@@ -178,7 +182,7 @@ def load_sample_file_with_validation_rules_step(context, sample_file_name, valid
     sample_validation_rules = get_validation_rules(validation_rules_path)
     sensitive_columns = get_sample_sensitive_columns(sample_validation_rules)
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
     context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
     collection_instrument_selection_rules = [
         {
@@ -187,12 +191,14 @@ def load_sample_file_with_validation_rules_step(context, sample_file_name, valid
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.sample = read_sample(sample_file_path, sample_validation_rules)
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,
+                                                                       sensitive_columns)
 
 
 def get_business_sample_columns_and_validation_rules(sample_file_path: Path):
@@ -238,7 +244,7 @@ def load_business_sample_file_step(context):
     sample_file_path = Config.SAMPLE_FILES_PATH.joinpath('business_rsi_example_sample.csv')
     sample_rows, validation_rules = get_business_sample_columns_and_validation_rules(sample_file_path)
 
-    context.survey_id = add_survey(validation_rules, "http://foo.bar.json", False, ':')
+    context.survey_id = add_survey(validation_rules, context.test_start_utc_datetime, "http://foo.bar.json", False, ':')
     context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
     collection_instrument_selection_rules = [
         {
@@ -247,11 +253,12 @@ def load_business_sample_file_step(context):
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
 
 @step('sample file "{sample_file_name}" with sensitive columns {sensitive_columns:array} is loaded successfully')
@@ -260,7 +267,7 @@ def load_sample_file_step_for_sensitive_data_multi_column(context, sample_file_n
     sample_rows, sample_validation_rules = get_sample_rows_and_generate_open_validation_rules(sample_file_path,
                                                                                               sensitive_columns)
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
     context.expected_collection_instrument_url = "http://test-eq.com/test-schema"
     collection_instrument_selection_rules = [
         {
@@ -269,11 +276,13 @@ def load_sample_file_step_for_sensitive_data_multi_column(context, sample_file_n
             "collectionInstrumentUrl": context.expected_collection_instrument_url
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,
+                                                                       sensitive_columns)
 
 
 @step('sample file "{sample_file_name}" is loaded with rules "{validation_rules_file_name}" '
@@ -286,7 +295,7 @@ def load_sample_with_rules_and_eq_launch_settings(context, sample_file_name, val
     sample_validation_rules = get_validation_rules(validation_rules_path)
     sensitive_columns = get_sample_sensitive_columns(sample_validation_rules)
 
-    context.survey_id = add_survey(sample_validation_rules)
+    context.survey_id = add_survey(sample_validation_rules, context.test_start_utc_datetime)
 
     eq_launch_settings_file_path = Config.EQ_LAUNCH_SETTINGS_FILE_PATH.joinpath(eq_launch_settings_file)
     context.eq_launch_settings = json.loads(eq_launch_settings_file_path.read_text())
@@ -300,9 +309,11 @@ def load_sample_with_rules_and_eq_launch_settings(context, sample_file_name, val
             "eqLaunchSettings": context.eq_launch_settings
         }
     ]
-    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules)
+    context.collex_id = add_collex(context.survey_id, collection_instrument_selection_rules,
+                                   context.test_start_utc_datetime)
 
     upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.sample = read_sample(sample_file_path, sample_validation_rules)
-    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, sensitive_columns)
+    context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,
+                                                                       sensitive_columns)

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -116,7 +116,7 @@ def create_and_upload_sensitive_update_file(context):
 
 @step("in the database the sensitive data has been updated as expected and is emitted redacted")
 def sensitive_data_updated_in_database_as_expected_and_is_emitted(context):
-    emitted_updated_cases = get_emitted_cases(len(context.bulk_sensitive_update))
+    emitted_updated_cases = get_emitted_cases(len(context.bulk_sensitive_update), context.test_start_utc_datetime)
 
     for expected_update in context.bulk_sensitive_update:
         db_sample_sensitive_dict = retry_check_sensitive_data_change(expected_update['caseId'],

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -23,7 +23,7 @@ def authorise_sms_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update()
+    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
 
     allowed_sms_fulfilments = survey_update_event['allowedSmsFulfilments']
     test_helper.assertEqual(len(allowed_sms_fulfilments), 1,

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -6,7 +6,7 @@ from behave import step
 
 from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
-from acceptance_tests.utilities.event_helper import get_exactly_one_emitted_survey_update
+from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_sms_fulfilment_response
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -23,7 +23,7 @@ def authorise_sms_pack_code(context):
     response = requests.post(url, json=body)
     response.raise_for_status()
 
-    survey_update_event = get_exactly_one_emitted_survey_update(context.test_start_utc_datetime)
+    survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)
 
     allowed_sms_fulfilments = survey_update_event['allowedSmsFulfilments']
     test_helper.assertEqual(len(allowed_sms_fulfilments), 1,

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -9,7 +9,8 @@ from tenacity import retry, stop_after_delay, wait_fixed
 from acceptance_tests.features.steps.email_action_rule import check_notify_called_with_correct_emails_and_uacs
 from acceptance_tests.features.steps.export_file import check_export_file
 from acceptance_tests.utilities.audit_trail_helper import get_random_alpha_numerics
-from acceptance_tests.utilities.event_helper import get_emitted_cases, get_collection_exercise_update_by_name, \
+from acceptance_tests.utilities.event_helper import get_emitted_cases, \
+    get_collection_exercise_update_by_name, \
     get_number_of_uac_update_events
 from acceptance_tests.utilities.sample_helper import read_sample
 from acceptance_tests.utilities.survey_helper import get_emitted_survey_update

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -10,7 +10,7 @@ from acceptance_tests.features.steps.email_action_rule import check_notify_calle
 from acceptance_tests.features.steps.export_file import check_export_file
 from acceptance_tests.utilities.audit_trail_helper import get_random_alpha_numerics
 from acceptance_tests.utilities.event_helper import get_emitted_cases, get_collection_exercise_update_by_name, \
-    get_uac_update_events
+    get_number_of_uac_update_events
 from acceptance_tests.utilities.sample_helper import read_sample
 from acceptance_tests.utilities.survey_helper import get_emitted_survey_update
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -157,7 +157,7 @@ def click_action_rule_button(context):
 @step('I can see the Action Rule has been triggered and export files have been created')
 def check_for_action_rule_triggered(context):
     poll_action_rule_trigger(context.browser, context.pack_code)
-    context.emitted_uacs = get_uac_update_events(context.sample_count, None, None, context.test_start_utc_datetime)
+    context.emitted_uacs = get_number_of_uac_update_events(context.sample_count, context.test_start_utc_datetime)
     check_export_file(context)
 
 

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -9,7 +9,7 @@ from tenacity import retry, stop_after_delay, wait_fixed
 from acceptance_tests.features.steps.email_action_rule import check_notify_called_with_correct_emails_and_uacs
 from acceptance_tests.features.steps.export_file import check_export_file
 from acceptance_tests.utilities.audit_trail_helper import get_random_alpha_numerics
-from acceptance_tests.utilities.event_helper import get_emitted_cases, get_emitted_collection_exercise_update, \
+from acceptance_tests.utilities.event_helper import get_emitted_cases, get_collection_exercise_update_by_name, \
     get_uac_update_events
 from acceptance_tests.utilities.sample_helper import read_sample
 from acceptance_tests.utilities.survey_helper import get_emitted_survey_update
@@ -48,7 +48,7 @@ def create_survey_in_UI(context, survey_prefix, sample_file_name, sensitive_colu
     test_helper.assertEquals(
         len(context.browser.find_by_id('surveyListTable').first.find_by_text(context.survey_name, wait_time=20)), 1)
 
-    get_emitted_survey_update(context.survey_name)
+    get_emitted_survey_update(context.survey_name, context.test_start_utc_datetime)
 
 
 @step('the survey is clicked on it should display the collection exercise page')
@@ -83,7 +83,7 @@ def click_create_collex_button(context):
     test_helper.assertEquals(
         len(context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name)), 1)
 
-    get_emitted_collection_exercise_update()
+    get_collection_exercise_update_by_name(context.collex_name, context.test_start_utc_datetime)
 
 
 @step('the collection exercise is clicked on, navigating to the selected exercise details page')
@@ -102,7 +102,7 @@ def click_load_sample(context, sample_file_name):
     context.browser.find_by_id("jobProcessBtn", wait_time=20).click()
     poll_sample_status_processed(context.browser)
     context.browser.find_by_id('closeSampledetailsBtn').click()
-    context.emitted_cases = get_emitted_cases(context.sample_count)
+    context.emitted_cases = get_emitted_cases(context.sample_count, context.test_start_utc_datetime)
 
     test_helper.assertEquals(len(context.emitted_cases), context.sample_count)
 
@@ -157,7 +157,7 @@ def click_action_rule_button(context):
 @step('I can see the Action Rule has been triggered and export files have been created')
 def check_for_action_rule_triggered(context):
     poll_action_rule_trigger(context.browser, context.pack_code)
-    context.emitted_uacs = get_uac_update_events(context.sample_count, None, None)
+    context.emitted_uacs = get_uac_update_events(context.sample_count, None, None, context.test_start_utc_datetime)
     check_export_file(context)
 
 

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -18,7 +18,8 @@ def create_export_file_action_rule(collex_id, classifiers, pack_code):
 
     response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
-    return pack_code
+    action_rule_id = str(response.text.strip('"'))
+    return action_rule_id
 
 
 def setup_deactivate_uac_action_rule(collex_id):
@@ -32,6 +33,8 @@ def setup_deactivate_uac_action_rule(collex_id):
 
     response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
+    action_rule_id = str(response.text.strip('"'))
+    return action_rule_id
 
 
 def setup_sms_action_rule(collex_id, pack_code):
@@ -47,6 +50,8 @@ def setup_sms_action_rule(collex_id, pack_code):
 
     response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
+    action_rule_id = str(response.text.strip('"'))
+    return action_rule_id
 
 
 def setup_email_action_rule(collex_id, pack_code):
@@ -62,6 +67,8 @@ def setup_email_action_rule(collex_id, pack_code):
 
     response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
+    action_rule_id = str(response.text.strip('"'))
+    return action_rule_id
 
 
 def set_eq_flush_action_rule(collex_id):

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -2,12 +2,12 @@ from datetime import datetime, timedelta
 
 import requests
 
-from acceptance_tests.utilities.event_helper import get_emitted_collection_exercise_update
+from acceptance_tests.utilities.event_helper import get_collection_exercise_update_by_name
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def add_collex(survey_id, collection_instrument_selection_rules):
+def add_collex(survey_id, collection_instrument_selection_rules, test_start_time):
     collex_name = 'test collex ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
     start_date = datetime.utcnow()
     end_date = start_date + timedelta(days=2)
@@ -27,7 +27,7 @@ def add_collex(survey_id, collection_instrument_selection_rules):
 
     collex_id = response.json()
 
-    collection_exercise_update_event = get_emitted_collection_exercise_update()
+    collection_exercise_update_event = get_collection_exercise_update_by_name(collex_name, test_start_time)
     test_helper.assertEqual(collection_exercise_update_event['name'], collex_name,
                             'Unexpected collection exercise name')
     test_helper.assertEqual(collection_exercise_update_event['surveyId'], survey_id,

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -1,15 +1,19 @@
+from functools import partial
+
 from tenacity import retry, wait_fixed, stop_after_delay
 
 from acceptance_tests.utilities.case_api_helper import get_logged_events_for_case_by_id
 from acceptance_tests.utilities.database_helper import open_cursor
-from acceptance_tests.utilities.pubsub_helper import get_exact_number_of_pubsub_messages
+from acceptance_tests.utilities.pubsub_helper import get_exact_number_of_pubsub_messages, \
+    get_matching_pubsub_message_acking_others
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def get_emitted_cases(expected_msg_count=1):
+def get_emitted_cases(expected_msg_count=1, test_start_time=None):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                                            expected_msg_count=expected_msg_count)
+                                                            expected_msg_count=expected_msg_count,
+                                                            test_start_time=test_start_time)
 
     case_payloads = []
     for message_received in messages_received:
@@ -20,9 +24,9 @@ def get_emitted_cases(expected_msg_count=1):
     return case_payloads
 
 
-def get_emitted_case_update(correlation_id, originating_user):
+def get_emitted_case_update(correlation_id, originating_user, test_start_time):
     message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                                           expected_msg_count=1)[0]
+                                                           expected_msg_count=1, test_start_time=test_start_time)[0]
 
     if correlation_id:
         test_helper.assertEqual(message_received['header']['correlationId'], correlation_id,
@@ -35,9 +39,9 @@ def get_emitted_case_update(correlation_id, originating_user):
     return message_received['payload']['caseUpdate']
 
 
-def get_emitted_uac_update(correlation_id, originating_user):
+def get_emitted_uac_update(correlation_id, originating_user, test_start_time):
     message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
-                                                           expected_msg_count=1)[0]
+                                                           expected_msg_count=1, test_start_time=test_start_time)[0]
 
     if correlation_id:
         test_helper.assertEqual(message_received['header']['correlationId'], correlation_id,
@@ -50,9 +54,10 @@ def get_emitted_uac_update(correlation_id, originating_user):
     return message_received['payload']['uacUpdate']
 
 
-def get_uac_update_events(expected_number, correlation_id, originating_user):
+def get_uac_update_events(expected_number, correlation_id, originating_user, test_start_time):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
-                                                            expected_msg_count=expected_number)
+                                                            expected_msg_count=expected_number,
+                                                            test_start_time=test_start_time)
 
     uac_payloads = []
     for uac_event in messages_received:
@@ -69,21 +74,29 @@ def get_uac_update_events(expected_number, correlation_id, originating_user):
     return uac_payloads
 
 
-def get_exactly_one_emitted_survey_update():
+def get_exactly_one_emitted_survey_update(test_start_time):
     message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
-                                                           expected_msg_count=1)[0]
+                                                           expected_msg_count=1,
+                                                           test_start_time=test_start_time)[0]
 
     return message_received['payload']['surveyUpdate']
 
 
-def get_emitted_collection_exercise_update():
-    message_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION,
-                                                           expected_msg_count=1)[0]
+def get_collection_exercise_update_by_name(collex_name, test_start_time):
+    def collex_name_matcher(message, expected_collex_name=None):
+        message_collex_name = message['payload']['collectionExerciseUpdate']['name']
+        return (True, None) if message_collex_name == expected_collex_name else \
+            (False, f'Collection exercise name "{message_collex_name}" did not match expected "{expected_collex_name}"')
+
+    message_received = get_matching_pubsub_message_acking_others(
+        Config.PUBSUB_OUTBOUND_COLLECTION_EXERCISE_SUBSCRIPTION,
+        partial(collex_name_matcher, expected_collex_name=collex_name),
+        test_start_time)
 
     return message_received['payload']['collectionExerciseUpdate']
 
 
-def get_emitted_case_events_by_type(case_id, type_filter):
+def get_logged_case_events_by_type(case_id, type_filter):
     events = get_logged_events_for_case_by_id(case_id)
 
     logged_event_of_type = []
@@ -105,9 +118,10 @@ def check_invalid_case_reason_matches_on_event(event_id, expected_reason):
                                 "The invalid case reason doesn't matched expected")
 
 
-def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted_cases, correlation_id,
-                                                                         active, field_to_test, expected_value):
-    emitted_uacs = get_uac_update_events(len(emitted_cases), correlation_id, None)
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted_cases, correlation_id, active,
+                                                                         field_to_test, expected_value,
+                                                                         test_start_time):
+    emitted_uacs = get_uac_update_events(len(emitted_cases), correlation_id, None, test_start_time=test_start_time)
     _check_uacs_updated_match_cases(emitted_uacs, emitted_cases)
     _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test, expected_value)
 

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from functools import partial
+from typing import Mapping, List, Optional
 
 from tenacity import retry, wait_fixed, stop_after_delay
 
@@ -10,10 +12,9 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def get_emitted_cases(expected_msg_count=1, test_start_time=None):
-    messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
-                                                            expected_msg_count=expected_msg_count,
-                                                            test_start_time=test_start_time)
+def get_emitted_cases(expected_msg_count=1, test_start_time: datetime = None):
+    messages_received = get_exact_number_of_pubsub_messages(
+        Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION, expected_msg_count, test_start_time=test_start_time)
 
     case_payloads = []
     for message_received in messages_received:
@@ -24,13 +25,14 @@ def get_emitted_cases(expected_msg_count=1, test_start_time=None):
     return case_payloads
 
 
-def _match_message_by_correlation_id(message, correlation_id: str = None):
+def _match_message_by_correlation_id(message: Mapping, correlation_id: str = None):
     if (message_cid := message['header']['correlationId']) != correlation_id:
         return False, f'Message correlation ID "{message_cid}" does not match expected "{correlation_id}"'
     return True, None
 
 
-def get_emitted_case_update(correlation_id, originating_user, test_start_time):
+def get_emitted_case_update_by_correlation_id(correlation_id: str, originating_user: Optional[str],
+                                              test_start_time: datetime):
     message_received = get_matching_pubsub_message_acking_others(Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
                                                                  partial(_match_message_by_correlation_id,
                                                                          correlation_id=correlation_id),
@@ -43,7 +45,7 @@ def get_emitted_case_update(correlation_id, originating_user, test_start_time):
     return message_received['payload']['caseUpdate']
 
 
-def get_emitted_uac_update(correlation_id, originating_user, test_start_time):
+def get_emitted_uac_update(correlation_id: str, originating_user: Optional[str], test_start_time: datetime):
     message_received = get_matching_pubsub_message_acking_others(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                                                  partial(_match_message_by_correlation_id,
                                                                          correlation_id=correlation_id),
@@ -56,7 +58,8 @@ def get_emitted_uac_update(correlation_id, originating_user, test_start_time):
     return message_received['payload']['uacUpdate']
 
 
-def get_uac_update_events(expected_number, correlation_id, originating_user, test_start_time):
+def get_uac_update_events(expected_number: int, correlation_id: str, originating_user: Optional[str],
+                          test_start_time: datetime):
     messages_received = get_matching_pubsub_messages_acking_others(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                                                    partial(_match_message_by_correlation_id,
                                                                            correlation_id=correlation_id),
@@ -75,13 +78,13 @@ def get_uac_update_events(expected_number, correlation_id, originating_user, tes
     return uac_payloads
 
 
-def _match_uac_linked_to_case_in_set(message, case_ids: set = None):
+def _match_uac_linked_to_case_in_set(message: Mapping, case_ids: set = None):
     if (case_id := message['payload']['uacUpdate']['caseId']) not in case_ids:
         return False, f'Uac linked to unexpected case ID "{case_id}", expected one of {case_ids}'
     return True, None
 
 
-def get_uac_update_events_matching_cases(cases, test_start_time):
+def get_uac_update_events_matching_cases(cases: List[Mapping], test_start_time: datetime):
     messages_received = get_matching_pubsub_messages_acking_others(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                                                    partial(_match_uac_linked_to_case_in_set,
                                                                            case_ids={case['caseId'] for case in cases}),
@@ -96,14 +99,14 @@ def get_uac_update_events_matching_cases(cases, test_start_time):
     return uac_payloads
 
 
-def get_number_of_uac_update_events(expected_number, test_start_time):
+def get_number_of_uac_update_events(expected_number: int, test_start_time: datetime):
     messages_received = get_exact_number_of_pubsub_messages(Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                                                             expected_msg_count=expected_number,
                                                             test_start_time=test_start_time)
     return [uac_event['payload']['uacUpdate'] for uac_event in messages_received]
 
 
-def get_emitted_survey_update_by_id(survey_id, test_start_time):
+def get_emitted_survey_update_by_id(survey_id: str, test_start_time: datetime):
     def match_survey_id(message, expected_survey_id: str = None):
         if message_survey_id := message['payload']['surveyUpdate']['surveyId'] != expected_survey_id:
             return False, (f'Failed match on message survey ID, found "{message_survey_id}",'
@@ -118,7 +121,7 @@ def get_emitted_survey_update_by_id(survey_id, test_start_time):
     return message_received['payload']['surveyUpdate']
 
 
-def get_collection_exercise_update_by_name(collex_name, test_start_time):
+def get_collection_exercise_update_by_name(collex_name: str, test_start_time: datetime):
     def collex_name_matcher(message, expected_collex_name=None):
         message_collex_name = message['payload']['collectionExerciseUpdate']['name']
         return (True, None) if message_collex_name == expected_collex_name else \
@@ -131,7 +134,7 @@ def get_collection_exercise_update_by_name(collex_name, test_start_time):
     return message_received['payload']['collectionExerciseUpdate']
 
 
-def get_logged_case_events_by_type(case_id, type_filter):
+def get_logged_case_events_by_type(case_id: str, type_filter: str):
     events = get_logged_events_for_case_by_id(case_id)
 
     logged_event_of_type = []
@@ -144,7 +147,7 @@ def get_logged_case_events_by_type(case_id, type_filter):
 
 
 @retry(wait=wait_fixed(1), stop=stop_after_delay(30))
-def check_invalid_case_reason_matches_on_event(event_id, expected_reason):
+def check_invalid_case_reason_matches_on_event(event_id: str, expected_reason: str):
     with open_cursor() as cur:
         cur.execute("SELECT payload FROM casev3.event WHERE id = %s", (event_id,))
         result = cur.fetchone()
@@ -153,9 +156,12 @@ def check_invalid_case_reason_matches_on_event(event_id, expected_reason):
                                 "The invalid case reason doesn't matched expected")
 
 
-def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted_cases, correlation_id, active,
-                                                                         field_to_test, expected_value,
-                                                                         test_start_time):
+def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted_cases: List[Mapping],
+                                                                         correlation_id: str,
+                                                                         active: bool,
+                                                                         field_to_test: str,
+                                                                         expected_value: bool,
+                                                                         test_start_time: datetime):
     emitted_uacs = get_uac_update_events(len(emitted_cases), correlation_id, None, test_start_time=test_start_time)
     _check_uacs_updated_match_cases(emitted_uacs, emitted_cases)
     _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test, expected_value)
@@ -163,9 +169,11 @@ def check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value(emitted
     return emitted_uacs
 
 
-def check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_value(emitted_cases, active,
-                                                                                   field_to_test, expected_value,
-                                                                                   test_start_time):
+def check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_value(emitted_cases: List[Mapping],
+                                                                                   active: bool,
+                                                                                   field_to_test: str,
+                                                                                   expected_value: bool,
+                                                                                   test_start_time: datetime):
     emitted_uacs = get_uac_update_events_matching_cases(emitted_cases, test_start_time=test_start_time)
     _check_uacs_updated_match_cases(emitted_uacs, emitted_cases)
     _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test, expected_value)
@@ -173,7 +181,7 @@ def check_uac_update_msgs_emitted_for_cases_with_qid_active_and_field_equals_val
     return emitted_uacs
 
 
-def _check_uacs_updated_match_cases(uac_update_events, cases):
+def _check_uacs_updated_match_cases(uac_update_events: List[Mapping], cases: List[Mapping]):
     test_helper.assertSetEqual(set(uac['caseId'] for uac in uac_update_events),
                                set(case['caseId'] for case in cases),
                                'The UAC updated events should be linked to the given set of case IDs')
@@ -184,7 +192,8 @@ def _check_uacs_updated_match_cases(uac_update_events, cases):
                             f'cases {cases}')
 
 
-def _check_new_uacs_are_as_expected(emitted_uacs, active, field_to_test=None, expected_value=None):
+def _check_new_uacs_are_as_expected(emitted_uacs: List[Mapping], active: bool, field_to_test: str = None,
+                                    expected_value: bool = None):
     for uac in emitted_uacs:
         test_helper.assertEqual(uac['active'], active, f"UAC {uac} active status doesn't equal expected {active}")
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 from datetime import datetime
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Optional
 
 from google.api_core.exceptions import DeadlineExceeded
 from google.cloud import pubsub_v1
@@ -18,7 +18,6 @@ subscriptions = [Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
                  Config.PUBSUB_OUTBOUND_UAC_SUBSCRIPTION,
                  Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
                  Config.PUBSUB_CLOUD_TASK_QUEUE_AT_SUBSCRIPTION, ]
-
 
 def publish_to_pubsub(message, project, topic, **kwargs):
     publisher = pubsub_v1.PublisherClient()
@@ -97,7 +96,6 @@ def _pull_exact_number_of_messages(subscriber, subscription_path, expected_msg_c
             if is_message_from_before_scenario(message, test_start_time):
                 # Ignore messages from before the test start time, to avoid cross contamination from early scenarios
                 logger.warn('Ignoring and acking a message from before this scenario', message=message)
-                print('Ignoring and acking a message from before this scenario', message)
                 continue
 
             scenario_messages.append(message)
@@ -125,7 +123,7 @@ def get_exact_number_of_pubsub_messages(subscription, expected_msg_count, timeou
 
 
 def get_matching_pubsub_message_acking_others(subscription,
-                                              message_matcher: Callable[[Mapping], tuple[bool, str]],
+                                              message_matcher: Callable[[Mapping], tuple[bool, Optional[str]]],
                                               test_start_time,
                                               timeout=Config.PUBSUB_DEFAULT_PULL_TIMEOUT):
     """
@@ -148,7 +146,7 @@ def get_matching_pubsub_message_acking_others(subscription,
 
 
 def get_matching_pubsub_messages_acking_others(subscription,
-                                               message_matcher: Callable[[Mapping], tuple[bool, str]],
+                                               message_matcher: Callable[[Mapping], tuple[bool, Optional[str]]],
                                                test_start_time,
                                                number_of_messages: int = 1,
                                                timeout=Config.PUBSUB_DEFAULT_PULL_TIMEOUT):

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -19,6 +19,7 @@ subscriptions = [Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
                  Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION,
                  Config.PUBSUB_CLOUD_TASK_QUEUE_AT_SUBSCRIPTION, ]
 
+
 def publish_to_pubsub(message, project, topic, **kwargs):
     publisher = pubsub_v1.PublisherClient()
 

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -9,8 +9,8 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def add_survey(sample_validation_rules, sample_definition_url="http://foo.bar.json", sample_has_header_row=True,
-               sample_file_separator=','):
+def add_survey(sample_validation_rules, test_start_time, sample_definition_url="http://foo.bar.json",
+               sample_has_header_row=True, sample_file_separator=','):
     survey_name = 'test survey ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 
     url = f'{Config.SUPPORT_TOOL_API}/surveys'
@@ -27,7 +27,7 @@ def add_survey(sample_validation_rules, sample_definition_url="http://foo.bar.js
 
     survey_id = response.json()
 
-    survey_update_event = get_emitted_survey_update(survey_name)
+    survey_update_event = get_emitted_survey_update(survey_name, test_start_time)
     test_helper.assertEqual(survey_update_event['name'], survey_name,
                             'Unexpected survey name')
 
@@ -40,12 +40,12 @@ def add_survey(sample_validation_rules, sample_definition_url="http://foo.bar.js
     return survey_id
 
 
-def get_emitted_survey_update(expected_survey_name):
+def get_emitted_survey_update(expected_survey_name, test_start_time):
     # Build the matcher with the current expected survey name
     survey_name_matcher = partial(_survey_name_message_matcher, expected_survey_name=expected_survey_name)
 
     message_received = get_matching_pubsub_message_acking_others(Config.PUBSUB_OUTBOUND_SURVEY_SUBSCRIPTION,
-                                                                 survey_name_matcher)
+                                                                 survey_name_matcher, test_start_time)
 
     return message_received['payload']['surveyUpdate']
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
We have issues, especially in the GCP cloud with PubSub messages being double delivered. Typically, it happens with "cold" PubSub subscriptions, where acks seems to sometimes fail, or take a long time to go through, allowing messages to be re-delivered even if our apps have successfully ack'ed them. To combat this, this change introduces a few improvements to how the tests consume messages. First, it introduces a filter to the messages consumption functions which ignores and acks messages with a timestamp from before the start of the current scenario. Second, it switches more of the functions to use message matching, acking non-matching messages, rather than simply assuming the first n messages found on the subscription are the messages it is looking for. 

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Add filter to PubSub consumer helpers to ignore messages timestamped before the current scenario start
- Utilize message matching in more places
- Improve naming and type hinting
 
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/7JQnqAFr/502-acceptance-tests-store-consumed-message-ids-and-ignore-left-over-messages-if-they-are-a-duplicate-of-an-already-seen-message-8
