### PR TITLE
Speed up ATs

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -128,3 +128,17 @@ def example(bar: List):
 ```gherkin
 When this step receives an array parameter ["spam", "eggs"]
 ```
+
+### SMS/Print/Email Templates
+The templates used for action rules and fulfilments are set up in the `before_all` environment step prior to whatever test(s) are running so that they can be used repeatedly.
+The templates are held in .json files within the `resources/template_files` directory and there is a file for each of the type.
+
+The template format is a list, and this list holds the fields to be included on the template, for example a template consisting of a sensitive email address and a uac would look like: 
+
+```["__sensitive__.emailAddress","__uac__"]```
+
+The corresponding format to use the template in a feature step would be:
+
+```"sensitive_emailaddress__uac"```
+
+So to add a new template, find the appropriate .json file and add a new block, add the template list to the template value, and the templateName value would be the list but converted so it is single underscore where there would be dot notation, and double underscores to show the gap between two list items as can be seen above between email address and uac.

--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -130,10 +130,14 @@ When this step receives an array parameter ["spam", "eggs"]
 ```
 
 ### SMS/Print/Email Templates
-The templates used for action rules and fulfilments are set up in the `before_all` environment step prior to whatever test(s) are running so that they can be used repeatedly.
-The templates are held in .json files within the `resources/template_files` directory and there is a file for each of the type.
 
-The template format is a list, and this list holds the fields to be included on the template, for example a template consisting of a sensitive email address and a uac would look like: 
+The templates used for action rules and fulfilments are set up in the `before_all` environment step prior to whatever
+test(s) are running so that they can be used repeatedly.
+The templates are held in .json files within the `resources/template_files` directory and there is a file for each of
+the type.
+
+The template format is a list, and this list holds the fields to be included on the template, for example a template
+consisting of a sensitive email address and a uac would look like:
 
 ```["__sensitive__.emailAddress","__uac__"]```
 
@@ -141,4 +145,7 @@ The corresponding format to use the template in a feature step would be:
 
 ```"sensitive_emailaddress__uac"```
 
-So to add a new template, find the appropriate .json file and add a new block, add the template list to the template value, and the templateName value would be the list but converted so it is single underscore where there would be dot notation, and double underscores to show the gap between two list items as can be seen above between email address and uac.
+So to add a new template, find the appropriate .json file and add a new block, add the template list to the template
+value, and the templateName value would be the list but converted so it is single underscore where there would be dot
+notation, and double underscores to show the gap between two list items as can be seen above between email address and
+uac.

--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -71,7 +71,13 @@ logging upon failure in the [audit_trail_helper](/acceptance_tests/utilities/aud
 | rh_launch_qid                      | Stores a qid paired with the UAC used for launching in RH                           | str      |
 | rh_launch_endpoint_response        | Stores the response from the API call RH launch                                     | str      |
 | eq_launch_claims                   | Stores the decrypted EQ launch claims json                                          | Mapping  | 
-| eq_flush_claims                    | Stores the decrypted EQ flush claims json                                           | Mapping  | 
+| eq_flush_claims                    | Stores the decrypted EQ flush claims json                                           | Mapping  |
+| email_templates                    | Stores the list of email templates setup prior to the tests                         | Mapping  |
+| email_packcodes                    | Stores the list of email packcodes setup prior to the tests                         | Mapping  |
+| export_file_templates              | Stores the list of export file templates setup prior to the tests                   | Mapping  |
+| export_file_packcodes              | Stores the list of export packcodes setup prior to the tests                        | Mapping  |
+| sms_templates                      | Stores the list of sms templates setup prior to the tests                           | Mapping  |
+| sms_packcodes                      | Stores the list of sms packcodes setup prior to the tests                           | Mapping  |
 
 </div>
 

--- a/acceptance_tests/features/RH_UI.feature
+++ b/acceptance_tests/features/RH_UI.feature
@@ -8,9 +8,9 @@ Feature: Testing the "enter a UAC" functionality of RH UI
     And link text displays string "<expected link test>"
 
     Examples:
-      | language code | expected error text                                          | error section header               | expected link test                                           |
-      | en            | Access code not recognised. Enter the code again.            | There is a problem with this page  | Access code not recognised. Enter the code again.            |
-      | cy            | Nid yw'r cod mynediad yn cael ei gydnabod. Rhowch y cod eto. | Mae problem gyda'r dudalen hon     | Nid yw'r cod mynediad yn cael ei gydnabod. Rhowch y cod eto. |
+      | language code | expected error text                                          | error section header              | expected link test                                           |
+      | en            | Access code not recognised. Enter the code again.            | There is a problem with this page | Access code not recognised. Enter the code again.            |
+      | cy            | Nid yw'r cod mynediad yn cael ei gydnabod. Rhowch y cod eto. | Mae problem gyda'r dudalen hon    | Nid yw'r cod mynediad yn cael ei gydnabod. Rhowch y cod eto. |
 
   @reset_notify_stub
   Scenario Outline: Works with a good UAC
@@ -21,9 +21,9 @@ Feature: Testing the "enter a UAC" functionality of RH UI
     And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is true
 
     Examples:
-      | language code | expected text                           |
-      | en            | Start study - ONS Surveys               |
-      | cy            | Dechrau'r astudiaeth - Arolygon SYG     |
+      | language code | expected text                       |
+      | en            | Start study - ONS Surveys           |
+      | cy            | Dechrau'r astudiaeth - Arolygon SYG |
 
   @reset_notify_stub
   Scenario: A receipted UAC redirects to informative page

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -10,12 +10,14 @@ Feature: Test basic Support Tool Functionality
     And the collection exercise is clicked on, navigating to the selected exercise details page
     Then I click the upload sample file button with file "social_sample_3_lines_fields.csv"
 
+  @regression
   Scenario: Create an export file template
     Given the support tool landing page is displayed
     And the Create Export File Template button is clicked on
     When an export file template with packcode "export-file-packcode" and template ["__uac__"] has been created
     Then I should see the export file template in the template list
 
+  @regression
   Scenario: Create an Export File Action Rule
     Given the support tool landing page is displayed
     And the Create Export File Template button is clicked on
@@ -32,6 +34,7 @@ Feature: Test basic Support Tool Functionality
     Then I can see the Action Rule has been triggered and export files have been created
 
   @reset_notify_stub
+  @regression
   Scenario: Create an Email Action Rule
     Given the support tool landing page is displayed
     And the Create Email Template button is clicked on

--- a/acceptance_tests/features/collection_instument.feature
+++ b/acceptance_tests/features/collection_instument.feature
@@ -4,13 +4,12 @@ Feature: choose collection instruments for cases
   @regression
   Scenario: A selection rule chooses the correct collection instrument based on case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex case CI selection rules
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
 
   Scenario: A selection rule chooses the correct collection instrument based on UAC metadata and case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex UAC CI selection rules
-    And an sms template has been created with template uac_qid
-    And fulfilments are authorised on sms template
+    And fulfilments are authorised for sms template "uac__qid"
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/collection_instument.feature
+++ b/acceptance_tests/features/collection_instument.feature
@@ -4,13 +4,13 @@ Feature: choose collection instruments for cases
   @regression
   Scenario: A selection rule chooses the correct collection instrument based on case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex case CI selection rules
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
 
   Scenario: A selection rule chooses the correct collection instrument based on UAC metadata and case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully with complex UAC CI selection rules
-    And an sms template has been created with template ["__uac__", "__qid__"]
+    And an sms template has been created with template uac_qid
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/deactivate_uac.feature
+++ b/acceptance_tests/features/deactivate_uac.feature
@@ -3,7 +3,7 @@ Feature: deactivate UACs for a case
   @regression
   Scenario: A case is loaded, action rule is triggered and UAC is deactivated for that case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a deactivate uac action rule has been created
@@ -12,7 +12,7 @@ Feature: deactivate UACs for a case
 
   Scenario: A deactivate UAC event is received for a QID and the UAC is deactivated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a deactivate uac message is put on the queue

--- a/acceptance_tests/features/deactivate_uac.feature
+++ b/acceptance_tests/features/deactivate_uac.feature
@@ -3,7 +3,7 @@ Feature: deactivate UACs for a case
   @regression
   Scenario: A case is loaded, action rule is triggered and UAC is deactivated for that case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a deactivate uac action rule has been created
@@ -12,7 +12,7 @@ Feature: deactivate UACs for a case
 
   Scenario: A deactivate UAC event is received for a QID and the UAC is deactivated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a deactivate uac message is put on the queue

--- a/acceptance_tests/features/email_action_rule.feature
+++ b/acceptance_tests/features/email_action_rule.feature
@@ -3,7 +3,7 @@ Feature: Check action rule for email feature is able to send email via notify
   @reset_notify_stub
   Scenario: An email is sent via action rule
     Given sample file "sis_survey_link.csv" with sensitive columns ["firstName","lastName","childFirstName","childMiddleNames","childLastName","childDob","mobileNumber","emailAddress","consentGivenTest","consentGivenSurvey"] is loaded successfully
-    And an email template has been created with template sensitive_childlastname__uac
+    And an email template has been created with template "sensitive_childlastname__uac"
     When an email action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
     And the events logged against the case are ["NEW_CASE","ACTION_RULE_EMAIL_REQUEST","ACTION_RULE_EMAIL_CONFIRMATION"]

--- a/acceptance_tests/features/email_action_rule.feature
+++ b/acceptance_tests/features/email_action_rule.feature
@@ -3,7 +3,7 @@ Feature: Check action rule for email feature is able to send email via notify
   @reset_notify_stub
   Scenario: An email is sent via action rule
     Given sample file "sis_survey_link.csv" with sensitive columns ["firstName","lastName","childFirstName","childMiddleNames","childLastName","childDob","mobileNumber","emailAddress","consentGivenTest","consentGivenSurvey"] is loaded successfully
-    And an email template has been created with template ["__sensitive__.childLastName","__uac__"]
+    And an email template has been created with template sensitive_childlastname__uac
     When an email action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
     And the events logged against the case are ["NEW_CASE","ACTION_RULE_EMAIL_REQUEST","ACTION_RULE_EMAIL_CONFIRMATION"]

--- a/acceptance_tests/features/email_driven_survey.feature
+++ b/acceptance_tests/features/email_driven_survey.feature
@@ -4,7 +4,7 @@ Feature: SRM supports simple, email driven surveys
   @reset_notify_stub
   Scenario: A simple email sample driven survey can be run in SRM
     Given the sample file "email_driven.csv" with validation rules "email_driven_rules.json" is loaded successfully
-    And an email template has been created with template ["__sensitive__.emailAddress","__uac__"]
+    And an email template has been created with template sensitive_emailaddress_uac
     When an email action rule has been created
     Then 5 UAC_UPDATE messages are emitted with active set to true
     And notify api was called with the correct emails from sample field "emailAddress" and notify template

--- a/acceptance_tests/features/email_driven_survey.feature
+++ b/acceptance_tests/features/email_driven_survey.feature
@@ -4,7 +4,7 @@ Feature: SRM supports simple, email driven surveys
   @reset_notify_stub
   Scenario: A simple email sample driven survey can be run in SRM
     Given the sample file "email_driven.csv" with validation rules "email_driven_rules.json" is loaded successfully
-    And an email template has been created with template sensitive_emailaddress_uac
+    And an email template has been created with template "sensitive_emailaddress__uac"
     When an email action rule has been created
     Then 5 UAC_UPDATE messages are emitted with active set to true
     And notify api was called with the correct emails from sample field "emailAddress" and notify template

--- a/acceptance_tests/features/email_fulfilment.feature
+++ b/acceptance_tests/features/email_fulfilment.feature
@@ -3,8 +3,7 @@ Feature: Email fulfilment
   @reset_notify_stub
   Scenario: An email fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template uac_qid
-    And fulfilments are authorised on email template
+    And fulfilments are authorised for email template "uac__qid"
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the email fulfilment UAC
@@ -15,8 +14,7 @@ Feature: Email fulfilment
   @regression
   Scenario: An email fulfilment is requested for a case with no uac/qid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template empty
-    And fulfilments are authorised on email template
+    And fulfilments are authorised for email template "empty"
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
     And notify api was called with the correct email template and values
@@ -25,8 +23,7 @@ Feature: Email fulfilment
   @regression
   Scenario: An email fulfilment is requested including personalisation
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template request_name
-    And fulfilments are authorised on email template
+    And fulfilments are authorised for email template "empty"
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz" with personalisation {"name": "Joe Bloggs"}
     Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
     And notify api was called with the correct email template and values

--- a/acceptance_tests/features/email_fulfilment.feature
+++ b/acceptance_tests/features/email_fulfilment.feature
@@ -3,7 +3,7 @@ Feature: Email fulfilment
   @reset_notify_stub
   Scenario: An email fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template ["__uac__", "__qid__"]
+    And an email template has been created with template uac_qid
     And fulfilments are authorised on email template
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then UAC_UPDATE messages are emitted with active set to true
@@ -15,7 +15,7 @@ Feature: Email fulfilment
   @regression
   Scenario: An email fulfilment is requested for a case with no uac/qid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template []
+    And an email template has been created with template empty
     And fulfilments are authorised on email template
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]
@@ -25,7 +25,7 @@ Feature: Email fulfilment
   @regression
   Scenario: An email fulfilment is requested including personalisation
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template ["__request__.name"]
+    And an email template has been created with template request_name
     And fulfilments are authorised on email template
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz" with personalisation {"name": "Joe Bloggs"}
     Then the events logged against the case are ["NEW_CASE","EMAIL_FULFILMENT"]

--- a/acceptance_tests/features/eq_flush.feature
+++ b/acceptance_tests/features/eq_flush.feature
@@ -3,7 +3,7 @@ Feature: Un-submitted eQ partials can be flushed automatically by action rule
   @reset_notify_stub
   Scenario: An eQ flush action rule generates the correct PubSub cloud task messages
     Given sample file "1_ROW_EMAIL.csv" with sensitive columns ["emailAddress"] is loaded successfully
-    And an email template has been created with template ["__uac__"]
+    And an email template has been created with template uac
     And an email action rule has been created
     And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     And an EQ_LAUNCH event is received
@@ -16,7 +16,7 @@ Feature: Un-submitted eQ partials can be flushed automatically by action rule
   @reset_notify_stub
   Scenario: An eQ flush action rule triggers the calls to the eQ flush endpoint
     Given sample file "1_ROW_EMAIL.csv" with sensitive columns ["emailAddress"] is loaded successfully
-    And an email template has been created with template ["__uac__","__qid__"]
+    And an email template has been created with template uac_qid
     And an email action rule has been created
     And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     And we retrieve the UAC and QID from the email log to use for launching in RH

--- a/acceptance_tests/features/eq_flush.feature
+++ b/acceptance_tests/features/eq_flush.feature
@@ -3,7 +3,7 @@ Feature: Un-submitted eQ partials can be flushed automatically by action rule
   @reset_notify_stub
   Scenario: An eQ flush action rule generates the correct PubSub cloud task messages
     Given sample file "1_ROW_EMAIL.csv" with sensitive columns ["emailAddress"] is loaded successfully
-    And an email template has been created with template uac
+    And an email template has been created with template "uac"
     And an email action rule has been created
     And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     And an EQ_LAUNCH event is received
@@ -16,7 +16,7 @@ Feature: Un-submitted eQ partials can be flushed automatically by action rule
   @reset_notify_stub
   Scenario: An eQ flush action rule triggers the calls to the eQ flush endpoint
     Given sample file "1_ROW_EMAIL.csv" with sensitive columns ["emailAddress"] is loaded successfully
-    And an email template has been created with template uac_qid
+    And an email template has been created with template "uac__qid"
     And an email action rule has been created
     And UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     And we retrieve the UAC and QID from the email log to use for launching in RH

--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -2,7 +2,7 @@ Feature: Handle EQ launch events
 
   Scenario: EQ launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     And an export file action rule has been created
     Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     When an EQ_LAUNCH event is received

--- a/acceptance_tests/features/eq_launched.feature
+++ b/acceptance_tests/features/eq_launched.feature
@@ -2,7 +2,7 @@ Feature: Handle EQ launch events
 
   Scenario: EQ launched events are logged and the case flag is updated
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     And an export file action rule has been created
     Then UAC_UPDATE message is emitted with active set to true and "eqLaunched" is false
     When an EQ_LAUNCH event is received

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -10,16 +10,16 @@ Feature: Export files can be created and sent with correct data
 
     Examples:
       | sample file                      | template                                               |
-      | social_sample_3_lines_fields.csv | ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE","__uac__"] |
+      | social_sample_3_lines_fields.csv | address_line1__address_line2__postcode__uac |
 
     @regression
     Examples:
       | sample file                 | template                                                     |
-      | business_sample_6_lines.csv | ["BUSINESS_NAME","TOWN_NAME","__uac__","__qid__","INDUSTRY"] |
+      | business_sample_6_lines.csv | business_name__town_name__uac__qid__industry|
 
   Scenario: Export file containing sensitive case fields
     Given the sample file "CRIS_dummy_1_row.csv" with validation rules "CRIS_validation_rules_v1.json" is loaded successfully
-    And an export file template has been created with template ["__sensitive__.MIDDLE_NAME","__sensitive__.LAST_NAME"]
+    And an export file template has been created with template sensitive_middle_name__sensitive_last_name
     When an export file action rule has been created
     And an export file is created with correct rows
     And the events logged against the cases are ["NEW_CASE","EXPORT_FILE"]
@@ -33,16 +33,16 @@ Feature: Export files can be created and sent with correct data
 
     Examples:
       | sample file                      | template                                     |
-      | social_sample_3_lines_fields.csv | ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE"] |
+      | social_sample_3_lines_fields.csv | address_line1__address_line2__postcode|
 
     @regression
     Examples:
       | sample file                 | template                                 |
-      | business_sample_6_lines.csv | ["BUSINESS_NAME","TOWN_NAME","INDUSTRY"] |
+      | business_sample_6_lines.csv | business_name__town_name__industry |
 
   Scenario Outline: A case is loaded action rule triggered and export file created with differing classifiers
     Given sample file "<sample file>" is loaded successfully
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     When an export file action rule has been created with classifiers "<classifiers>"
     Then <expected row count> UAC_UPDATE messages are emitted with active set to true
     Then an export file is created with correct rows

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -2,7 +2,7 @@ Feature: Export files can be created and sent with correct data
 
   Scenario Outline: A case is loaded, action rule triggered and export file created with differing templates with UACs
     Given sample file "<sample file>" is loaded successfully
-    And an export file template has been created with template <template>
+    And an export file template has been created with template "<template>"
     When an export file action rule has been created
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
@@ -26,7 +26,7 @@ Feature: Export files can be created and sent with correct data
 
   Scenario Outline: A case is loaded, action rule triggered and export file created with differing templates no UACs
     Given sample file "<sample file>" is loaded successfully
-    And an export file template has been created with template <template>
+    And an export file template has been created with template "<template>"
     When an export file action rule has been created
     And an export file is created with correct rows
     And the events logged against the cases are ["NEW_CASE","EXPORT_FILE"]

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -9,13 +9,13 @@ Feature: Export files can be created and sent with correct data
     And the events logged against the cases are ["NEW_CASE","EXPORT_FILE"]
 
     Examples:
-      | sample file                      | template                                               |
+      | sample file                      | template                                    |
       | social_sample_3_lines_fields.csv | address_line1__address_line2__postcode__uac |
 
     @regression
     Examples:
-      | sample file                 | template                                                     |
-      | business_sample_6_lines.csv | business_name__town_name__uac__qid__industry|
+      | sample file                 | template                                     |
+      | business_sample_6_lines.csv | business_name__town_name__uac__qid__industry |
 
   Scenario: Export file containing sensitive case fields
     Given the sample file "CRIS_dummy_1_row.csv" with validation rules "CRIS_validation_rules_v1.json" is loaded successfully
@@ -32,12 +32,12 @@ Feature: Export files can be created and sent with correct data
     And the events logged against the cases are ["NEW_CASE","EXPORT_FILE"]
 
     Examples:
-      | sample file                      | template                                     |
-      | social_sample_3_lines_fields.csv | address_line1__address_line2__postcode|
+      | sample file                      | template                               |
+      | social_sample_3_lines_fields.csv | address_line1__address_line2__postcode |
 
     @regression
     Examples:
-      | sample file                 | template                                 |
+      | sample file                 | template                           |
       | business_sample_6_lines.csv | business_name__town_name__industry |
 
   Scenario Outline: A case is loaded action rule triggered and export file created with differing classifiers

--- a/acceptance_tests/features/export_file.feature
+++ b/acceptance_tests/features/export_file.feature
@@ -19,7 +19,7 @@ Feature: Export files can be created and sent with correct data
 
   Scenario: Export file containing sensitive case fields
     Given the sample file "CRIS_dummy_1_row.csv" with validation rules "CRIS_validation_rules_v1.json" is loaded successfully
-    And an export file template has been created with template sensitive_middle_name__sensitive_last_name
+    And an export file template has been created with template "sensitive_middle_name__sensitive_last_name"
     When an export file action rule has been created
     And an export file is created with correct rows
     And the events logged against the cases are ["NEW_CASE","EXPORT_FILE"]
@@ -42,7 +42,7 @@ Feature: Export files can be created and sent with correct data
 
   Scenario Outline: A case is loaded action rule triggered and export file created with differing classifiers
     Given sample file "<sample file>" is loaded successfully
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     When an export file action rule has been created with classifiers "<classifiers>"
     Then <expected row count> UAC_UPDATE messages are emitted with active set to true
     Then an export file is created with correct rows

--- a/acceptance_tests/features/load_sample.feature
+++ b/acceptance_tests/features/load_sample.feature
@@ -3,6 +3,6 @@ Feature: Sample files of all accepted shapes can be loaded
   @regression
   Scenario: A BOM sample file is loaded
     Given BOM sample file "LMS_Test_Sample_RM_BOM.csv" is loaded successfully
-    And an export file template has been created with template ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE"]
+    And an export file template has been created with template address_line1__address_line2__postcode
     When an export file action rule has been created
     And an export file is created with correct rows

--- a/acceptance_tests/features/load_sample.feature
+++ b/acceptance_tests/features/load_sample.feature
@@ -3,6 +3,6 @@ Feature: Sample files of all accepted shapes can be loaded
   @regression
   Scenario: A BOM sample file is loaded
     Given BOM sample file "LMS_Test_Sample_RM_BOM.csv" is loaded successfully
-    And an export file template has been created with template address_line1__address_line2__postcode
+    And an export file template has been created with template "address_line1__address_line2__postcode"
     When an export file action rule has been created
     And an export file is created with correct rows

--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -6,7 +6,6 @@ Feature: Print fulfilments can be requested for a case
     And an export file template has been created with template address_line1__postcode__uac
     And fulfilments are authorised on the export file template
     And a print fulfilment has been requested
-#    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
@@ -17,7 +16,6 @@ Feature: Print fulfilments can be requested for a case
     And an export file template has been created with template request_name__address_line1__postcode__uac
     And fulfilments are authorised on the export file template
     And a print fulfilment with personalisation {"name":"Joe Bloggs"} has been requested
-#    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows

--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -3,10 +3,10 @@ Feature: Print fulfilments can be requested for a case
   @regression
   Scenario: A print fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["ADDRESS_LINE1","POSTCODE","__uac__"]
+    And an export file template has been created with template address_line1__postcode__uac
     And fulfilments are authorised on the export file template
     And a print fulfilment has been requested
-    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
+#    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows
@@ -14,10 +14,10 @@ Feature: Print fulfilments can be requested for a case
 
   Scenario: A print fulfilment including personalisation is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["__request__.name","ADDRESS_LINE1","POSTCODE","__uac__"]
+    And an export file template has been created with template request_name__address_line1__postcode__uac
     And fulfilments are authorised on the export file template
     And a print fulfilment with personalisation {"name":"Joe Bloggs"} has been requested
-    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
+#    And the events logged against the case are ["NEW_CASE","PRINT_FULFILMENT"]
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
     And an export file is created with correct rows

--- a/acceptance_tests/features/print_fulfilment.feature
+++ b/acceptance_tests/features/print_fulfilment.feature
@@ -3,8 +3,7 @@ Feature: Print fulfilments can be requested for a case
   @regression
   Scenario: A print fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template address_line1__postcode__uac
-    And fulfilments are authorised on the export file template
+    And fulfilments are authorised for the export file template "address_line1__postcode__uac"
     And a print fulfilment has been requested
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true
@@ -13,8 +12,7 @@ Feature: Print fulfilments can be requested for a case
 
   Scenario: A print fulfilment including personalisation is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template request_name__address_line1__postcode__uac
-    And fulfilments are authorised on the export file template
+    And fulfilments are authorised for the export file template "request_name__address_line1__postcode__uac"
     And a print fulfilment with personalisation {"name":"Joe Bloggs"} has been requested
     When export file fulfilments are triggered to be exported
     Then UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -2,7 +2,7 @@ Feature: A case can be receipted with an event
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template ["__uac__"]
+    And an export file template has been created with template uac
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic

--- a/acceptance_tests/features/receipting.feature
+++ b/acceptance_tests/features/receipting.feature
@@ -2,7 +2,7 @@ Feature: A case can be receipted with an event
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an export file template has been created with template uac
+    And an export file template has been created with template "uac"
     And an export file action rule has been created
     And UAC_UPDATE messages are emitted with active set to true
     When a receipt message is published to the pubsub receipting topic

--- a/acceptance_tests/features/rh_ui_api_launch.feature
+++ b/acceptance_tests/features/rh_ui_api_launch.feature
@@ -3,8 +3,7 @@ Feature: Launch a survey with a claims token from Respondent Home UI using a UAC
   @reset_notify_stub
   Scenario: Post a UAC to the launch endpoint and get redirected to a launch URL with a claims token
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template uac_qid
-    And fulfilments are authorised on sms template
+    And fulfilments are authorised for sms template "uac__qid"
     And a request has been made for a replacement UAC by SMS from phone number "07123456789"
     And UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the SMS fulfilment UAC

--- a/acceptance_tests/features/rh_ui_api_launch.feature
+++ b/acceptance_tests/features/rh_ui_api_launch.feature
@@ -3,7 +3,7 @@ Feature: Launch a survey with a claims token from Respondent Home UI using a UAC
   @reset_notify_stub
   Scenario: Post a UAC to the launch endpoint and get redirected to a launch URL with a claims token
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template ["__uac__", "__qid__"]
+    And an sms template has been created with template uac_qid
     And fulfilments are authorised on sms template
     And a request has been made for a replacement UAC by SMS from phone number "07123456789"
     And UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/sdx_receipt.feature
+++ b/acceptance_tests/features/sdx_receipt.feature
@@ -2,7 +2,7 @@ Feature: A case can be receipted with an event from sdx
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template ["__uac__", "__qid__"]
+    And an email template has been created with template uac_qid
     And fulfilments are authorised on email template
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then UAC_UPDATE messages are emitted with active set to true

--- a/acceptance_tests/features/sdx_receipt.feature
+++ b/acceptance_tests/features/sdx_receipt.feature
@@ -2,8 +2,7 @@ Feature: A case can be receipted with an event from sdx
 
   Scenario: A case is loaded and can be receipted
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an email template has been created with template uac_qid
-    And fulfilments are authorised on email template
+    And fulfilments are authorised for email template "uac__qid"
     When a request has been made for a replacement UAC by email from email address "foo@bar.baz"
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the email fulfilment UAC

--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -3,7 +3,7 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
   @reset_notify_stub
   Scenario: A SMS message is sent via action rule
     Given sample file "sis_survey_link.csv" with sensitive columns ["firstName","lastName","childFirstName","childMiddleNames","childLastName","childDob","mobileNumber","emailAddress","consentGivenTest","consentGivenSurvey"] is loaded successfully
-    And an sms template has been created with template sensitive_childlastname__uac
+    And an sms template has been created with template "sensitive_childlastname__uac"
     When a SMS action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
     And the events logged against the case are ["NEW_CASE","ACTION_RULE_SMS_REQUEST","ACTION_RULE_SMS_CONFIRMATION"]

--- a/acceptance_tests/features/sms_action_rule.feature
+++ b/acceptance_tests/features/sms_action_rule.feature
@@ -3,7 +3,7 @@ Feature: Check action rule for SMS feature is able to send SMS via notify
   @reset_notify_stub
   Scenario: A SMS message is sent via action rule
     Given sample file "sis_survey_link.csv" with sensitive columns ["firstName","lastName","childFirstName","childMiddleNames","childLastName","childDob","mobileNumber","emailAddress","consentGivenTest","consentGivenSurvey"] is loaded successfully
-    And an sms template has been created with template ["__sensitive__.childLastName","__uac__"]
+    And an sms template has been created with template sensitive_childlastname__uac
     When a SMS action rule has been created
     Then 1 UAC_UPDATE messages are emitted with active set to true
     And the events logged against the case are ["NEW_CASE","ACTION_RULE_SMS_REQUEST","ACTION_RULE_SMS_CONFIRMATION"]

--- a/acceptance_tests/features/sms_fulfilment.feature
+++ b/acceptance_tests/features/sms_fulfilment.feature
@@ -3,8 +3,7 @@ Feature: Sms fulfilment
   @reset_notify_stub
   Scenario: A SMS fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template uac_qid
-    And fulfilments are authorised on sms template
+    And fulfilments are authorised for sms template "uac__qid"
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true
     And the UAC_UPDATE message matches the SMS fulfilment UAC
@@ -15,8 +14,7 @@ Feature: Sms fulfilment
   @regression
   Scenario: A SMS fulfilment is requested for a case with no uac/qid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template empty
-    And fulfilments are authorised on sms template
+    And fulfilments are authorised for sms template "empty"
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
     And notify api was called with the correct SMS template and values
@@ -25,8 +23,7 @@ Feature: Sms fulfilment
   @regression
   Scenario: A SMS fulfilment is requested including personalisation
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template request_name
-    And fulfilments are authorised on sms template
+    And fulfilments are authorised for sms template "request_name"
     When a request has been made for a replacement UAC by SMS from phone number "07123456789" with personalisation {"name": "Joe Bloggs"}
     Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
     And notify api was called with the correct SMS template and values

--- a/acceptance_tests/features/sms_fulfilment.feature
+++ b/acceptance_tests/features/sms_fulfilment.feature
@@ -3,7 +3,7 @@ Feature: Sms fulfilment
   @reset_notify_stub
   Scenario: A SMS fulfilment is requested for a case
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template ["__uac__", "__qid__"]
+    And an sms template has been created with template uac_qid
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then UAC_UPDATE messages are emitted with active set to true
@@ -15,7 +15,7 @@ Feature: Sms fulfilment
   @regression
   Scenario: A SMS fulfilment is requested for a case with no uac/qid
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template []
+    And an sms template has been created with template empty
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789"
     Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]
@@ -25,7 +25,7 @@ Feature: Sms fulfilment
   @regression
   Scenario: A SMS fulfilment is requested including personalisation
     Given sample file "sample_1_limited_address_fields.csv" is loaded successfully
-    And an sms template has been created with template ["__request__.name"]
+    And an sms template has been created with template request_name
     And fulfilments are authorised on sms template
     When a request has been made for a replacement UAC by SMS from phone number "07123456789" with personalisation {"name": "Joe Bloggs"}
     Then the events logged against the case are ["NEW_CASE","SMS_FULFILMENT"]

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -10,11 +10,11 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised for email template {template_name}")
+@step('fulfilments are authorised for email template "{template_name}"')
 def authorise_sms_pack_code(context, template_name):
-    context.template = context.email_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.email_packcodes[template_name.strip('\"')]['pack_code']
-    context.notify_template_id = context.email_packcodes[template_name.strip('\"')]['notify_template_id']
+    context.template = context.email_templates[template_name]['template']
+    context.pack_code = context.email_packcodes[template_name]['pack_code']
+    context.notify_template_id = context.email_packcodes[template_name]['notify_template_id']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyEmailTemplates'
     body = {
@@ -84,8 +84,8 @@ def check_uac_message_matches_email_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an email template has been created with template {template_name}')
+@step('an email template has been created with template "{template_name}"')
 def create_email_template(context, template_name):
-    context.template = context.email_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.email_packcodes[template_name.strip('\"')]['pack_code']
-    context.notify_template_id = context.email_packcodes[template_name.strip('\"')]['notify_template_id']
+    context.template = context.email_templates[template_name]['template']
+    context.pack_code = context.email_packcodes[template_name]['pack_code']
+    context.notify_template_id = context.email_packcodes[template_name]['notify_template_id']

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -1,10 +1,8 @@
 import uuid
-from typing import List
 
 import requests
 from behave import step
 
-from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_email_fulfilment_response
@@ -82,7 +80,8 @@ def check_uac_message_matches_email_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an email template has been created with template {template:array}')
-def create_email_template(context, template: List):
-    context.template = template
-    context.pack_code, context.notify_template_id = template_helper.create_email_template(template)
+@step('an email template has been created with template {templateName}')
+def create_email_template(context, templateName):
+    context.template = context.email_templates[templateName]['template']
+    context.pack_code = context.email_packcodes[templateName]['pack_code']
+    context.notify_template_id = context.email_packcodes[templateName]['notify_template_id']

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -10,8 +10,12 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised on email template")
-def authorise_sms_pack_code(context):
+@step("fulfilments are authorised for email template {templateName}")
+def authorise_sms_pack_code(context, templateName):
+    context.template = context.email_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.email_packcodes[templateName.strip('\"')]['pack_code']
+    context.notify_template_id = context.email_packcodes[templateName.strip('\"')]['notify_template_id']
+
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyEmailTemplates'
     body = {
         'surveyId': context.survey_id,
@@ -82,6 +86,6 @@ def check_uac_message_matches_email_uac(context):
 
 @step('an email template has been created with template {templateName}')
 def create_email_template(context, templateName):
-    context.template = context.email_templates[templateName]['template']
-    context.pack_code = context.email_packcodes[templateName]['pack_code']
-    context.notify_template_id = context.email_packcodes[templateName]['notify_template_id']
+    context.template = context.email_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.email_packcodes[templateName.strip('\"')]['pack_code']
+    context.notify_template_id = context.email_packcodes[templateName.strip('\"')]['notify_template_id']

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -10,11 +10,11 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised for email template {templateName}")
-def authorise_sms_pack_code(context, templateName):
-    context.template = context.email_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.email_packcodes[templateName.strip('\"')]['pack_code']
-    context.notify_template_id = context.email_packcodes[templateName.strip('\"')]['notify_template_id']
+@step("fulfilments are authorised for email template {template_name}")
+def authorise_sms_pack_code(context, template_name):
+    context.template = context.email_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.email_packcodes[template_name.strip('\"')]['pack_code']
+    context.notify_template_id = context.email_packcodes[template_name.strip('\"')]['notify_template_id']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyEmailTemplates'
     body = {
@@ -84,8 +84,8 @@ def check_uac_message_matches_email_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an email template has been created with template {templateName}')
-def create_email_template(context, templateName):
-    context.template = context.email_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.email_packcodes[templateName.strip('\"')]['pack_code']
-    context.notify_template_id = context.email_packcodes[templateName.strip('\"')]['notify_template_id']
+@step('an email template has been created with template {template_name}')
+def create_email_template(context, template_name):
+    context.template = context.email_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.email_packcodes[template_name.strip('\"')]['pack_code']
+    context.notify_template_id = context.email_packcodes[template_name.strip('\"')]['notify_template_id']

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -43,10 +43,10 @@ def check_export_file(context):
     check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
 
 
-@step('an export file template has been created with template {templateName}')
-def create_export_file_template(context, templateName):
-    context.template = context.export_file_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.export_file_packcodes[templateName.strip('\"')]['pack_code']
+@step('an export file template has been created with template {template_name}')
+def create_export_file_template(context, template_name):
+    context.template = context.export_file_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.export_file_packcodes[template_name.strip('\"')]['pack_code']
 
 
 @step('an export file template has been created for the internal reprographics supplier with template {template:array}')

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -45,8 +45,8 @@ def check_export_file(context):
 
 @step('an export file template has been created with template {templateName}')
 def create_export_file_template(context, templateName):
-    context.template = context.export_file_templates[templateName]['template']
-    context.pack_code = context.export_file_packcodes[templateName]['pack_code']
+    context.template = context.export_file_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.export_file_packcodes[templateName.strip('\"')]['pack_code']
 
 
 @step('an export file template has been created for the internal reprographics supplier with template {template:array}')

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -43,10 +43,10 @@ def check_export_file(context):
     check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
 
 
-@step('an export file template has been created with template {template:array}')
-def create_export_file_template(context, template: List):
-    context.template = template
-    context.pack_code = template_helper.create_export_file_template(template)
+@step('an export file template has been created with template {templateName}')
+def create_export_file_template(context, templateName):
+    context.template = context.export_file_templates[templateName]['template']
+    context.pack_code = context.export_file_packcodes[templateName]['pack_code']
 
 
 @step('an export file template has been created for the internal reprographics supplier with template {template:array}')

--- a/acceptance_tests/features/steps/export_file.py
+++ b/acceptance_tests/features/steps/export_file.py
@@ -43,10 +43,10 @@ def check_export_file(context):
     check_export_file_matches_expected(actual_export_file_rows, expected_export_file_rows)
 
 
-@step('an export file template has been created with template {template_name}')
+@step('an export file template has been created with template "{template_name}"')
 def create_export_file_template(context, template_name):
-    context.template = context.export_file_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.export_file_packcodes[template_name.strip('\"')]['pack_code']
+    context.template = context.export_file_templates[template_name]['template']
+    context.pack_code = context.export_file_packcodes[template_name]['pack_code']
 
 
 @step('an export file template has been created for the internal reprographics supplier with template {template:array}')

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -55,10 +55,10 @@ def print_fulfilments_trigger_step(context):
     response.raise_for_status()
 
 
-@step("fulfilments are authorised for the export file template {template_name}")
+@step('fulfilments are authorised for the export file template "{template_name}"')
 def authorise_pack_code(context, template_name):
-    context.template = context.export_file_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.export_file_packcodes[template_name.strip('\"')]['pack_code']
+    context.template = context.export_file_templates[template_name]['template']
+    context.pack_code = context.export_file_packcodes[template_name]['pack_code']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyExportFileTemplates'
     body = {

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -55,10 +55,10 @@ def print_fulfilments_trigger_step(context):
     response.raise_for_status()
 
 
-@step("fulfilments are authorised for the export file template {templateName}")
-def authorise_pack_code(context, templateName):
-    context.template = context.export_file_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.export_file_packcodes[templateName.strip('\"')]['pack_code']
+@step("fulfilments are authorised for the export file template {template_name}")
+def authorise_pack_code(context, template_name):
+    context.template = context.export_file_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.export_file_packcodes[template_name.strip('\"')]['pack_code']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyExportFileTemplates'
     body = {

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -55,8 +55,11 @@ def print_fulfilments_trigger_step(context):
     response.raise_for_status()
 
 
-@step("fulfilments are authorised on the export file template")
-def authorise_pack_code(context):
+@step("fulfilments are authorised for the export file template {templateName}")
+def authorise_pack_code(context, templateName):
+    context.template = context.export_file_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.export_file_packcodes[templateName.strip('\"')]['pack_code']
+
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveyExportFileTemplates'
     body = {
         'surveyId': context.survey_id,

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -143,7 +143,7 @@ def _redirect_to_eq(context, language_code):
 
 @step('and we request a UAC by SMS and the UAC is ready and RH page has "{expected_text}" for "{language_code}"')
 def we_request_a_UAC_via_SMS_and_check_the_UAC_in_firestore_and_page_is_ready(context, expected_text, language_code):
-    create_sms_template(context, ["__uac__", "__qid__"])
+    create_sms_template(context, 'uac_qid')
     authorise_sms_pack_code(context)
     request_replacement_uac_by_sms(context, "07123456789")
     check_uac_update_msgs_emitted_with_qid_active(context, True)

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -5,7 +5,7 @@ from behave import step
 
 from acceptance_tests.features.steps.events_emitted import check_uac_update_msgs_emitted_with_qid_active
 from acceptance_tests.features.steps.notify_api import get_uac_from_sms_fulfilment
-from acceptance_tests.features.steps.sms_fulfilment import create_sms_template, authorise_sms_pack_code, \
+from acceptance_tests.features.steps.sms_fulfilment import authorise_sms_pack_code, \
     request_replacement_uac_by_sms, check_uac_message_matches_sms_uac
 from acceptance_tests.utilities import rh_endpoint_client
 from acceptance_tests.utilities.event_helper import check_uac_update_msgs_emitted_with_qid_active_and_field_equals_value
@@ -143,8 +143,7 @@ def _redirect_to_eq(context, language_code):
 
 @step('and we request a UAC by SMS and the UAC is ready and RH page has "{expected_text}" for "{language_code}"')
 def we_request_a_UAC_via_SMS_and_check_the_UAC_in_firestore_and_page_is_ready(context, expected_text, language_code):
-    create_sms_template(context, 'uac_qid')
-    authorise_sms_pack_code(context)
+    authorise_sms_pack_code(context, 'uac__qid')
     request_replacement_uac_by_sms(context, "07123456789")
     check_uac_update_msgs_emitted_with_qid_active(context, True)
     check_uac_message_matches_sms_uac(context)

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -10,11 +10,11 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised for sms template {template_name}")
+@step('fulfilments are authorised for sms template "{template_name}"')
 def authorise_sms_pack_code(context, template_name):
-    context.template = context.sms_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.sms_packcodes[template_name.strip('\"')]['pack_code']
-    context.notify_template_id = context.sms_packcodes[template_name.strip('\"')]['notify_template_id']
+    context.template = context.sms_templates[template_name]['template']
+    context.pack_code = context.sms_packcodes[template_name]['pack_code']
+    context.notify_template_id = context.sms_packcodes[template_name]['notify_template_id']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveySmsTemplates'
     body = {
@@ -84,8 +84,8 @@ def check_uac_message_matches_sms_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an sms template has been created with template {template_name}')
+@step('an sms template has been created with template "{template_name}"')
 def create_sms_template(context, template_name):
-    context.template = context.sms_templates[template_name.strip('\"')]['template']
-    context.pack_code = context.sms_packcodes[template_name.strip('\"')]['pack_code']
-    context.notify_template_id = context.sms_packcodes[template_name.strip('\"')]['notify_template_id']
+    context.template = context.sms_templates[template_name]['template']
+    context.pack_code = context.sms_packcodes[template_name]['pack_code']
+    context.notify_template_id = context.sms_packcodes[template_name]['notify_template_id']

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -10,11 +10,11 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised for sms template {templateName}")
-def authorise_sms_pack_code(context, templateName):
-    context.template = context.sms_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.sms_packcodes[templateName.strip('\"')]['pack_code']
-    context.notify_template_id = context.sms_packcodes[templateName.strip('\"')]['notify_template_id']
+@step("fulfilments are authorised for sms template {template_name}")
+def authorise_sms_pack_code(context, template_name):
+    context.template = context.sms_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.sms_packcodes[template_name.strip('\"')]['pack_code']
+    context.notify_template_id = context.sms_packcodes[template_name.strip('\"')]['notify_template_id']
 
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveySmsTemplates'
     body = {
@@ -84,8 +84,8 @@ def check_uac_message_matches_sms_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an sms template has been created with template {templateName}')
-def create_sms_template(context, templateName):
-    context.template = context.sms_templates[templateName.strip('\"')]['template']
-    context.pack_code = context.sms_packcodes[templateName.strip('\"')]['pack_code']
-    context.notify_template_id = context.sms_packcodes[templateName.strip('\"')]['notify_template_id']
+@step('an sms template has been created with template {template_name}')
+def create_sms_template(context, template_name):
+    context.template = context.sms_templates[template_name.strip('\"')]['template']
+    context.pack_code = context.sms_packcodes[template_name.strip('\"')]['pack_code']
+    context.notify_template_id = context.sms_packcodes[template_name.strip('\"')]['notify_template_id']

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -1,10 +1,8 @@
 import uuid
-from typing import List
 
 import requests
 from behave import step
 
-from acceptance_tests.utilities import template_helper
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_sms_fulfilment_response
@@ -82,7 +80,8 @@ def check_uac_message_matches_sms_uac(context):
                             f"context.fulfilment_response_json {context.fulfilment_response_json}")
 
 
-@step('an sms template has been created with template {template:array}')
-def create_sms_template(context, template: List):
-    context.template = template
-    context.pack_code, context.notify_template_id = template_helper.create_sms_template(template)
+@step('an sms template has been created with template {templateName}')
+def create_sms_template(context, templateName):
+    context.template = context.sms_templates[templateName]['template']
+    context.pack_code = context.sms_packcodes[templateName]['pack_code']
+    context.notify_template_id = context.sms_packcodes[templateName]['notify_template_id']

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -10,8 +10,12 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("fulfilments are authorised on sms template")
-def authorise_sms_pack_code(context):
+@step("fulfilments are authorised for sms template {templateName}")
+def authorise_sms_pack_code(context, templateName):
+    context.template = context.sms_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.sms_packcodes[templateName.strip('\"')]['pack_code']
+    context.notify_template_id = context.sms_packcodes[templateName.strip('\"')]['notify_template_id']
+
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentSurveySmsTemplates'
     body = {
         'surveyId': context.survey_id,
@@ -82,6 +86,6 @@ def check_uac_message_matches_sms_uac(context):
 
 @step('an sms template has been created with template {templateName}')
 def create_sms_template(context, templateName):
-    context.template = context.sms_templates[templateName]['template']
-    context.pack_code = context.sms_packcodes[templateName]['pack_code']
-    context.notify_template_id = context.sms_packcodes[templateName]['notify_template_id']
+    context.template = context.sms_templates[templateName.strip('\"')]['template']
+    context.pack_code = context.sms_packcodes[templateName.strip('\"')]['pack_code']
+    context.notify_template_id = context.sms_packcodes[templateName.strip('\"')]['notify_template_id']

--- a/resources/template_files/email_templates.json
+++ b/resources/template_files/email_templates.json
@@ -4,7 +4,7 @@
     "template": ["__uac__"]
   },
   {
-    "templateName": "uac_qid",
+    "templateName": "uac__qid",
     "template": ["__uac__", "__qid__"]
   },
   {
@@ -20,7 +20,7 @@
     "template": ["__sensitive__.childLastName","__uac__"]
   },
   {
-    "templateName": "sensitive_emailaddress_uac",
+    "templateName": "sensitive_emailaddress__uac",
     "template": ["__sensitive__.emailAddress","__uac__"]
   }
 ]

--- a/resources/template_files/email_templates.json
+++ b/resources/template_files/email_templates.json
@@ -1,0 +1,26 @@
+[
+  {
+    "templateName": "uac",
+    "template": ["__uac__"]
+  },
+  {
+    "templateName": "uac_qid",
+    "template": ["__uac__", "__qid__"]
+  },
+  {
+    "templateName": "empty",
+    "template": []
+  },
+  {
+    "templateName": "request_name",
+    "template": ["__request__.name"]
+  },
+  {
+    "templateName": "sensitive_childlastname__uac",
+    "template": ["__sensitive__.childLastName","__uac__"]
+  },
+  {
+    "templateName": "sensitive_emailaddress_uac",
+    "template": ["__sensitive__.emailAddress","__uac__"]
+  }
+]

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -4,7 +4,7 @@
     "template": ["__uac__"]
   },
   {
-    "templateName": "uac_qid",
+    "templateName": "uac__qid",
     "template": ["__uac__","__qid__"]
   },
   {

--- a/resources/template_files/export_file_templates.json
+++ b/resources/template_files/export_file_templates.json
@@ -1,0 +1,46 @@
+[
+  {
+    "templateName": "uac",
+    "template": ["__uac__"]
+  },
+  {
+    "templateName": "uac_qid",
+    "template": ["__uac__","__qid__"]
+  },
+  {
+    "templateName": "empty",
+    "template": []
+  },
+  {
+    "templateName": "address_line1__address_line2__postcode__uac",
+    "template": ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE","__uac__"]
+  },
+  {
+    "templateName": "business_name__town_name__uac__qid__industry",
+    "template": ["BUSINESS_NAME","TOWN_NAME","__uac__","__qid__","INDUSTRY"]
+  },
+  {
+    "templateName": "sensitive_middle_name__sensitive_last_name",
+    "template": ["__sensitive__.MIDDLE_NAME","__sensitive__.LAST_NAME"]
+  },
+  {
+    "templateName": "address_line1__address_line2__postcode",
+    "template": ["ADDRESS_LINE1","ADDRESS_LINE2","POSTCODE"]
+  },
+  {
+    "templateName": "business_name__town_name__industry",
+    "template": ["BUSINESS_NAME","TOWN_NAME","INDUSTRY"]
+  },
+  {
+    "templateName": "first_name__postcode",
+    "template": ["FIRST_NAME", "POSTCODE"]
+  },
+  {
+    "templateName": "address_line1__postcode__uac",
+    "template": ["ADDRESS_LINE1","POSTCODE","__uac__"]
+  },
+  {
+    "templateName": "request_name__address_line1__postcode__uac",
+    "template": ["__request__.name","ADDRESS_LINE1","POSTCODE","__uac__"]
+  }
+]

--- a/resources/template_files/sms_templates.json
+++ b/resources/template_files/sms_templates.json
@@ -1,0 +1,26 @@
+[
+  {
+    "templateName": "uac",
+    "template": ["__uac__"]
+  },
+  {
+    "templateName": "uac_qid",
+    "template": ["__uac__", "__qid__"]
+  },
+  {
+    "templateName": "empty",
+    "template": []
+  },
+  {
+    "templateName": "request_name",
+    "template": ["__request__.name"]
+  },
+  {
+    "templateName": "sensitive_childlastname__uac",
+    "template": ["__sensitive__.childLastName","__uac__"]
+  },
+  {
+    "templateName": "sensitive_emailaddress__uac",
+    "template": ["__sensitive__.emailAddress","__uac__"]
+  }
+]

--- a/resources/template_files/sms_templates.json
+++ b/resources/template_files/sms_templates.json
@@ -4,7 +4,7 @@
     "template": ["__uac__"]
   },
   {
-    "templateName": "uac_qid",
+    "templateName": "uac__qid",
     "template": ["__uac__", "__qid__"]
   },
   {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
The acceptance tests can take a while to run, we want to see if we can speed them up
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The biggest change is to the steps where a template is setup. As there are a number of tests that use the same template instead of repeated calls to the support too these are now setup prior to the tests running. The template details are now held in json files and read in so the format of the actual template in the step has changed so it looks similar to what it was before, but just using underscores, this is something that could be discussed if people have other ideas.

Some tests have been moved to regression
Some steps removed as they werent testing much.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the ATs on main and on this branch, both regression and non regression tests.
Do the same but in a GCP env
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/OGqY2vnd/677-speed-up-ats-5
# Screenshots (if appropriate):