### PR TITLE
Updating tests to use notify service ref for email/sms templates

### DIFF
--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -34,11 +34,10 @@ Feature: Test basic Support Tool Functionality
     Then I can see the Action Rule has been triggered and export files have been created
 
   @reset_notify_stub
-  @regression
-  Scenario: Create an Email Action Rule
+  Scenario Outline: Create an Email Action Rule
     Given the support tool landing page is displayed
     And the Create Email Template button is clicked on
-    And an email template with packcode "email-packcode" and template ["__uac__"] has been created
+    And an email template with packcode "email-packcode", notify service ref "<notify service ref>" and template ["__uac__"] has been created
     And I should see the email template in the template list
     And the Create Survey Button is clicked on
     And a Survey called "EmailTest" plus unique suffix is created for sample file "sis_survey_link.csv" with sensitive columns ["emailAddress"]
@@ -50,3 +49,9 @@ Feature: Test basic Support Tool Functionality
     When I create an email action rule with email column "emailAddress"
     Then I can see the Action Rule has been triggered and emails sent to notify api with email column "emailAddress"
     And the correct number of UAC_UPDATE messages are emitted with active set to true
+
+    @regression
+    Examples:
+      | notify service ref                           |
+      | Office_for_National_Statistics_surveys_UKHSA |
+      | test_service                                 |

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -176,16 +176,19 @@ def click_create_email_template_button(context):
     context.browser.find_by_id('openCreateEmailTemplateBtn').click()
 
 
-@step('an email template with packcode "{packcode}" and template {template:array} has been created')
-def create_email_template(context, packcode, template: List):
+@step('an email template with packcode "{packcode}", notify service ref "{notify_service_ref}" '
+      'and template {template:array} has been created')
+def create_email_template(context, packcode, notify_service_ref, template: List):
     context.pack_code = f'{packcode}-' + get_random_alpha_numerics(5)
     context.template = template
     context.notify_template_id = str(uuid.uuid4())
 
     context.browser.find_by_id('EmailPackcodeTextField').fill(context.pack_code)
-    context.browser.find_by_id('EmailDescriptionTextField').fill('export-file description')
+    context.browser.find_by_id('EmailDescriptionTextField').fill('email description')
     context.browser.find_by_id('EmailNotifyTemplateIdTextField').fill(context.notify_template_id)
     context.browser.find_by_id('EmailTemplateTextField').fill(str(context.template).replace('\'', '\"'))
+    context.browser.find_by_id('EmailNotifyServiceRef').click()
+    context.browser.find_by_id(notify_service_ref).click()
     context.browser.find_by_id('createEmailTemplateBtn').click()
 
 

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -16,6 +16,7 @@ def create_template(create_url, pack_code, template, notify_template_id=None, ex
     }
     if notify_template_id:
         body['notifyTemplateId'] = notify_template_id
+        body['notifyServiceRef'] = "test_service"
 
     if export_file_destination:
         body['exportFileDestination'] = export_file_destination


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
We're giving notify service the functionality to use multiple services depending on the gov_notify_ref that's passed into it. The tests need to be updated to set a gov_notify_ref for the tests.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the ATs with the other branches
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/gL7KBQtj)
