### PR TITLE
1282 hard coding a chrome version for acceptance test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "daily"
     labels:
       - "patch"
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "patch"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN CHROME_VERSION=$(google-chrome --version | awk '{print $3}') && \
     unzip /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/ && \
     mv /usr/local/bin/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
 
-# Install pipenvm
+# Install pipenv
 RUN pip3 install pipenv
 
 # set display port to avoid crash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.11-slim
+ENV LATEST_COMPATIBLE_CHROME_VERSION="120.0.6099.71-1"
 
 # install google chrome, chromedriver and add acceptancetest user
 RUN apt-get -y update && apt-get install -y curl git wget gnupg && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&  \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \
-&& apt-get -y update || true && apt-get install -y google-chrome-stable && apt-get install -yqq unzip && groupadd --gid 1000 acceptancetests && useradd --create-home --system --uid 1000 --gid acceptancetests acceptancetests
+    wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb && \
+    dpkg -i google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb || apt -y -f install && \
+    rm google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb && \
+    apt-get install -yqq unzip && groupadd --gid 1000 acceptancetests && useradd --create-home --system --uid 1000 --gid acceptancetests acceptancetests
 
 # Chrome and chromedriver share the same version (as of 115) so use this to download chromedriver directly
 RUN CHROME_VERSION=$(google-chrome --version | awk '{print $3}') && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.11-slim
-ENV LATEST_COMPATIBLE_CHROME_VERSION="120.0.6099.71-1"
 
 # install google chrome, chromedriver and add acceptancetest user
-RUN apt-get -y update && apt-get install -y curl git wget gnupg && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&  \
-    wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb && \
-    dpkg -i google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb || apt -y -f install && \
-    rm google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}_amd64.deb && \
+RUN apt-get -y update && apt-get install -y curl git wget gnupg jq && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&  \
+    LATEST_COMPATIBLE_CHROME_VERSION=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r '.channels."Stable"."version"') && \
+    wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb && \
+    dpkg -i google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb || apt -y -f install && \
+    rm google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb && \
     apt-get install -yqq unzip && groupadd --gid 1000 acceptancetests && useradd --create-home --system --uid 1000 --gid acceptancetests acceptancetests
 
 # Chrome and chromedriver share the same version (as of 115) so use this to download chromedriver directly
@@ -14,7 +14,7 @@ RUN CHROME_VERSION=$(google-chrome --version | awk '{print $3}') && \
     unzip /tmp/chromedriver.zip chromedriver-linux64/chromedriver -d /usr/local/bin/ && \
     mv /usr/local/bin/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
 
-# Install pipenv
+# Install pipenvm
 RUN pip3 install pipenv
 
 # set display port to avoid crash


### PR DESCRIPTION
# Motivation and Context
Building the acceptance test would keep failing due to the latest version of chrome not being supported by chrome driver.
This is a quick fix but a proper fix should be implemented at another date
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Docker file has been changed to install a specific version of chrome, it should pull the latest support version form chromedriver and install that version of chrome

I had to re-write the install, I tried to change `apt-get install -y google-chrome-stable=${VERSION}` - but it would only find the latest chrome version.
Instead it uses wget and dpkg to install chrome

# How to test?
See if you get no errors when running `make build`
Double check the acceptence tests still work

# Links
https://trello.com/c/KNuuuoFP

# Screenshots (if appropriate):