### PR TITLE
Update github-pr-label-checker to latest available version 1.6.13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch" ]
     labels:
       - "patch"
       - "dependencies"

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: docker://onsdigital/github-pr-label-checker:v1.2.7
+      - uses: docker://onsdigital/github-pr-label-checker:v1.6.13
         with:
           one_of: breaking change,feature,patch
           none_of: do not merge,work in progress


### PR DESCRIPTION
# Motivation and Context
We're currently using version 1.2.7 of the github-pr-label-checker, which is a log way behind the most recent version 1.6.13. Version 1.2.7 uses features that are now deprecated.

# What has changed
Updated the version of the label checker in the Git workflow.

# How to test?
The label checker running as part of this PR should run and pass as normal.  The logs should show that it's using the new version.

# Links
https://trello.com/c/TDpQHGaw