### PR TITLE
1348 Fix Regression Test

### DIFF
--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -17,7 +17,9 @@ from acceptance_tests.utilities.survey_helper import get_emitted_survey_update
 from acceptance_tests.utilities.test_case_helper import test_helper
 from acceptance_tests.utilities.validation_rule_helper import get_sample_rows_and_generate_open_validation_rules
 from config import Config
-
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 @step("the support tool landing page is displayed")
 def navigate_to_support_tool_landing_page(context):
@@ -59,7 +61,7 @@ def click_into_collex_page(context):
 
 @step('the create collection exercise button is clicked, the details are submitted and the exercise is created')
 def click_create_collex_button(context):
-    context.browser.find_by_id('createCollectionExerciseBtn').click()
+    context.browser.find_by_id('createCollectionExerciseBtn', wait_time=30).click()
     context.collex_name = 'test collex ' + datetime.now().strftime("%m/%d/%Y, %H:%M:%S")
 
     context.browser.find_by_id('collectionExerciseNameTextField').fill(context.collex_name)
@@ -90,7 +92,7 @@ def click_create_collex_button(context):
 @step('the collection exercise is clicked on, navigating to the selected exercise details page')
 def click_into_collex_details(context):
     context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name,
-                                                                                 wait_time=30).click()
+                                                                                wait_time=30).click()
 
 
 @step('I click the upload sample file button with file "{sample_file_name}"')
@@ -200,7 +202,11 @@ def find_created_email_template(context):
 
 @step("the email template has been added to the allow on action rule list")
 def allow_email_template_on_action_rule(context):
-    context.browser.find_by_id('allowEmailTemplateDialogBtn', wait_time=30).click()
+    context.browser.driver.refresh()
+    allowEmailTemplateDialogBtn = WebDriverWait(context.browser.driver, 30).until(
+        EC.element_to_be_clickable((By.ID, 'allowEmailTemplateDialogBtn'))
+    )
+    allowEmailTemplateDialogBtn.click()
     context.browser.find_by_id('selectEmailTemplate').click()
     context.browser.find_by_id(context.pack_code, wait_time=30).click()
     context.browser.find_by_id("allowEmailTemplateOnActionRule", wait_time=30).click()

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -21,6 +21,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+
 @step("the support tool landing page is displayed")
 def navigate_to_support_tool_landing_page(context):
     context.browser.visit(f'{Config.SUPPORT_TOOL_URL}')
@@ -92,7 +93,7 @@ def click_create_collex_button(context):
 @step('the collection exercise is clicked on, navigating to the selected exercise details page')
 def click_into_collex_details(context):
     context.browser.find_by_id('collectionExerciseTableList').first.find_by_text(context.collex_name,
-                                                                                wait_time=30).click()
+                                                                                 wait_time=30).click()
 
 
 @step('I click the upload sample file button with file "{sample_file_name}"')
@@ -203,10 +204,9 @@ def find_created_email_template(context):
 @step("the email template has been added to the allow on action rule list")
 def allow_email_template_on_action_rule(context):
     context.browser.driver.refresh()
-    allowEmailTemplateDialogBtn = WebDriverWait(context.browser.driver, 30).until(
+    WebDriverWait(context.browser.driver, 30).until(
         EC.element_to_be_clickable((By.ID, 'allowEmailTemplateDialogBtn'))
-    )
-    allowEmailTemplateDialogBtn.click()
+    ).click()
     context.browser.find_by_id('selectEmailTemplate').click()
     context.browser.find_by_id(context.pack_code, wait_time=30).click()
     context.browser.find_by_id("allowEmailTemplateOnActionRule", wait_time=30).click()


### PR DESCRIPTION
# Motivation and Context
Regression Tests kept failing occasionally
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Added in some minor fixes that should hopefully fix the failures;
- Added some extra wait_time for some of the buttons to give support tool time to load the buttons/page.
- Added a refresh before clicking 'allowEmailTemplateButton' as the page didn't always load properly
- Slightly changed the way the test waits for `allowEmailTemplateButton` to ensure the button is found

# How to test?
Build the test and push to docker ([Instructions on how to do it](https://github.com/ONSdigital/ssdc-rm-acceptance-tests?tab=readme-ov-file#run-tests-against-a-gcp-project)).
Run a ground zero script on your dev gcp project then run (in this repo): `ENV=<your_env> REGRESSION=true ./run_gke.sh` to run the regression test. It should pass all the checks (The main test to look out for is Scenario Outline: Create an Email Action Rule -- @1.2  in the Feature: Test basic Support Tool Functionality).  

# Links
https://trello.com/c/gx5gWo33

# Screenshots (if appropriate):