### PR TITLE
SDCSRM-360 Call support tool via HTTPS/IAP

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -68,11 +68,11 @@
         },
         "cachetools": {
             "hashes": [
-                "sha256:086ee420196f7b2ab9ca2db2520aca326318b68fe5ba8bc4d49cca91add450f2",
-                "sha256:861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1"
+                "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945",
+                "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==5.3.2"
+            "version": "==5.3.3"
         },
         "certifi": {
             "hashes": [
@@ -238,68 +238,60 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:087887e55e0b9c8724cf05361357875adb5c20dec27e5816b653492980d20380",
-                "sha256:09a77e5b2e8ca732a19a90c5bca2d124621a1edb5438c5daa2d2738bfeb02589",
-                "sha256:130c0f77022b2b9c99d8cebcdd834d81705f61c68e91ddd614ce74c657f8b3ea",
-                "sha256:141e2aa5ba100d3788c0ad7919b288f89d1fe015878b9659b307c9ef867d3a65",
-                "sha256:28cb2c41f131a5758d6ba6a0504150d644054fd9f3203a1e8e8d7ac3aea7f73a",
-                "sha256:2f9f14185962e6a04ab32d1abe34eae8a9001569ee4edb64d2304bf0d65c53f3",
-                "sha256:320948ab49883557a256eab46149df79435a22d2fefd6a66fe6946f1b9d9d008",
-                "sha256:36d4b7c4be6411f58f60d9ce555a73df8406d484ba12a63549c88bd64f7967f1",
-                "sha256:3b15c678f27d66d247132cbf13df2f75255627bcc9b6a570f7d2fd08e8c081d2",
-                "sha256:3dbd37e14ce795b4af61b89b037d4bc157f2cb23e676fa16932185a04dfbf635",
-                "sha256:4383b47f45b14459cab66048d384614019965ba6c1a1a141f11b5a551cace1b2",
-                "sha256:44c95c0e96b3cb628e8452ec060413a49002a247b2b9938989e23a2c8291fc90",
-                "sha256:4b063d3413f853e056161eb0c7724822a9740ad3caa24b8424d776cebf98e7ee",
-                "sha256:52ed9ebf8ac602385126c9a2fe951db36f2cb0c2538d22971487f89d0de4065a",
-                "sha256:55d1580e2d7e17f45d19d3b12098e352f3a37fe86d380bf45846ef257054b242",
-                "sha256:5ef9bc3d046ce83c4bbf4c25e1e0547b9c441c01d30922d812e887dc5f125c12",
-                "sha256:5fa82a26f92871eca593b53359c12ad7949772462f887c35edaf36f87953c0e2",
-                "sha256:61321672b3ac7aade25c40449ccedbc6db72c7f5f0fdf34def5e2f8b51ca530d",
-                "sha256:701171f825dcab90969596ce2af253143b93b08f1a716d4b2a9d2db5084ef7be",
-                "sha256:841ec8af7a8491ac76ec5a9522226e287187a3107e12b7d686ad354bb78facee",
-                "sha256:8a06641fb07d4e8f6c7dda4fc3f8871d327803ab6542e33831c7ccfdcb4d0ad6",
-                "sha256:8e88bb9eafbf6a4014d55fb222e7360eef53e613215085e65a13290577394529",
-                "sha256:a00aee5d1b6c20620161984f8ab2ab69134466c51f58c052c11b076715e72929",
-                "sha256:a047682d324ba56e61b7ea7c7299d51e61fd3bca7dad2ccc39b72bd0118d60a1",
-                "sha256:a7ef8dd0bf2e1d0a27042b231a3baac6883cdd5557036f5e8df7139255feaac6",
-                "sha256:ad28cff53f60d99a928dfcf1e861e0b2ceb2bc1f08a074fdd601b314e1cc9e0a",
-                "sha256:b9097a208875fc7bbeb1286d0125d90bdfed961f61f214d3f5be62cd4ed8a446",
-                "sha256:b97fe7d7991c25e6a31e5d5e795986b18fbbb3107b873d5f3ae6dc9a103278e9",
-                "sha256:e0ec52ba3c7f1b7d813cd52649a5b3ef1fc0d433219dc8c93827c57eab6cf888",
-                "sha256:ea2c3ffb662fec8bbbfce5602e2c159ff097a4631d96235fcf0fb00e59e3ece4",
-                "sha256:fa3dec4ba8fb6e662770b74f62f1a0c7d4e37e25b58b2bf2c1be4c95372b4a33",
-                "sha256:fbeb725c9dc799a574518109336acccaf1303c30d45c075c665c0793c2f79a7f"
+                "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee",
+                "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576",
+                "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d",
+                "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30",
+                "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413",
+                "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb",
+                "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da",
+                "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4",
+                "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd",
+                "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc",
+                "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8",
+                "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1",
+                "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc",
+                "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e",
+                "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8",
+                "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940",
+                "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400",
+                "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7",
+                "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16",
+                "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278",
+                "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74",
+                "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec",
+                "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1",
+                "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2",
+                "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c",
+                "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922",
+                "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a",
+                "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6",
+                "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1",
+                "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e",
+                "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
+                "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==42.0.2"
-        },
-        "deprecated": {
-            "hashes": [
-                "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c",
-                "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.14"
+            "version": "==42.0.5"
         },
         "google-api-core": {
             "extras": [
                 "grpc"
             ],
             "hashes": [
-                "sha256:032d37b45d1d6bdaf68fb11ff621e2593263a239fa9246e2e94325f9c47876d2",
-                "sha256:449ca0e3f14c179b4165b664256066c7861610f70b6ffe54bb01a04e9b466929"
+                "sha256:5a63aa102e0049abe85b5b88cb9409234c1f70afcda21ce1e40b285b9629c1d6",
+                "sha256:62d97417bfc674d6cef251e5c4d639a9655e00c45528c4364fbfebb478ce72a9"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.16.2"
+            "version": "==2.18.0"
         },
         "google-auth": {
             "hashes": [
-                "sha256:8e4bad367015430ff253fe49d500fdc3396c1a434db5740828c728e45bcce245",
-                "sha256:e863a56ccc2d8efa83df7a80272601e43487fa9a728a376205c86c26aaefa821"
+                "sha256:672dff332d073227550ffc7457868ac4218d6c500b155fe6cc17d2b13602c360",
+                "sha256:d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.27.0"
+            "version": "==2.29.0"
         },
         "google-cloud-core": {
             "hashes": [
@@ -311,21 +303,21 @@
         },
         "google-cloud-pubsub": {
             "hashes": [
-                "sha256:602eacbe5735f38d3ae384ece8f235db0594de78ad718a35fcb948dc4964612c",
-                "sha256:c10d95ebaf903f923b14aa8ec5b7c80916138edf299c65a1c1a9431fd5665d25"
+                "sha256:31fcf07444b7f813a616c4b650e1fbf1dc998a088fe0059a76164855ac17f05c",
+                "sha256:55a3602ec45bc09626604d712032288a8ee3566145cb83523cff908938f69a4b"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.19.1"
+            "version": "==2.21.1"
         },
         "google-cloud-storage": {
             "hashes": [
-                "sha256:2d23fcf59b55e7b45336729c148bb1c464468c69d5efbaee30f7201dd90eb97e",
-                "sha256:8641243bbf2a2042c16a6399551fbb13f062cbc9a2de38d6c0bb5426962e9dbd"
+                "sha256:91a06b96fb79cf9cdfb4e759f178ce11ea885c79938f89590344d079305f5852",
+                "sha256:dda485fa503710a828d01246bd16ce9db0823dc51bbca742ce96a6817d58669f"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==2.14.0"
+            "version": "==2.16.0"
         },
         "google-crc32c": {
             "hashes": [
@@ -414,11 +406,11 @@
                 "grpc"
             ],
             "hashes": [
-                "sha256:4750113612205514f9f6aa4cb00d523a94f3e8c06c5ad2fee466387dc4875f07",
-                "sha256:83f0ece9f94e5672cced82f592d2a5edf527a96ed1794f0bab36d5735c996277"
+                "sha256:17ad01b11d5f1d0171c06d3ba5c04c54474e883b66b949722b4938ee2694ef4e",
+                "sha256:ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.62.0"
+            "version": "==1.63.0"
         },
         "grpc-google-iam-v1": {
             "hashes": [
@@ -430,71 +422,71 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:0250a7a70b14000fa311de04b169cc7480be6c1a769b190769d347939d3232a8",
-                "sha256:069fe2aeee02dfd2135d562d0663fe70fbb69d5eed6eb3389042a7e963b54de8",
-                "sha256:082081e6a36b6eb5cf0fd9a897fe777dbb3802176ffd08e3ec6567edd85bc104",
-                "sha256:0c5807e9152eff15f1d48f6b9ad3749196f79a4a050469d99eecb679be592acc",
-                "sha256:14e8f2c84c0832773fb3958240c69def72357bc11392571f87b2d7b91e0bb092",
-                "sha256:2a6087f234cb570008a6041c8ffd1b7d657b397fdd6d26e83d72283dae3527b1",
-                "sha256:2bb2a2911b028f01c8c64d126f6b632fcd8a9ac975aa1b3855766c94e4107180",
-                "sha256:2f44c32aef186bbba254129cea1df08a20be414144ac3bdf0e84b24e3f3b2e05",
-                "sha256:30e980cd6db1088c144b92fe376747328d5554bc7960ce583ec7b7d81cd47287",
-                "sha256:33aed0a431f5befeffd9d346b0fa44b2c01aa4aeae5ea5b2c03d3e25e0071216",
-                "sha256:33bdea30dcfd4f87b045d404388469eb48a48c33a6195a043d116ed1b9a0196c",
-                "sha256:39aa848794b887120b1d35b1b994e445cc028ff602ef267f87c38122c1add50d",
-                "sha256:4216e67ad9a4769117433814956031cb300f85edc855252a645a9a724b3b6594",
-                "sha256:49c9b6a510e3ed8df5f6f4f3c34d7fbf2d2cae048ee90a45cd7415abab72912c",
-                "sha256:4eec8b8c1c2c9b7125508ff7c89d5701bf933c99d3910e446ed531cd16ad5d87",
-                "sha256:50d56280b482875d1f9128ce596e59031a226a8b84bec88cb2bf76c289f5d0de",
-                "sha256:53b69e79d00f78c81eecfb38f4516080dc7f36a198b6b37b928f1c13b3c063e9",
-                "sha256:55ccb7db5a665079d68b5c7c86359ebd5ebf31a19bc1a91c982fd622f1e31ff2",
-                "sha256:5a1ebbae7e2214f51b1f23b57bf98eeed2cf1ba84e4d523c48c36d5b2f8829ff",
-                "sha256:61b7199cd2a55e62e45bfb629a35b71fc2c0cb88f686a047f25b1112d3810904",
-                "sha256:660fc6b9c2a9ea3bb2a7e64ba878c98339abaf1811edca904ac85e9e662f1d73",
-                "sha256:6d140bdeb26cad8b93c1455fa00573c05592793c32053d6e0016ce05ba267549",
-                "sha256:6e490fa5f7f5326222cb9f0b78f207a2b218a14edf39602e083d5f617354306f",
-                "sha256:6ecf21d20d02d1733e9c820fb5c114c749d888704a7ec824b545c12e78734d1c",
-                "sha256:70c83bb530572917be20c21f3b6be92cd86b9aecb44b0c18b1d3b2cc3ae47df0",
-                "sha256:72153a0d2e425f45b884540a61c6639436ddafa1829a42056aa5764b84108b8e",
-                "sha256:73e14acd3d4247169955fae8fb103a2b900cfad21d0c35f0dcd0fdd54cd60367",
-                "sha256:76eaaba891083fcbe167aa0f03363311a9f12da975b025d30e94b93ac7a765fc",
-                "sha256:79ae0dc785504cb1e1788758c588c711f4e4a0195d70dff53db203c95a0bd303",
-                "sha256:7d142bcd604166417929b071cd396aa13c565749a4c840d6c702727a59d835eb",
-                "sha256:8c9554ca8e26241dabe7951aa1fa03a1ba0856688ecd7e7bdbdd286ebc272e4c",
-                "sha256:8d488fbdbf04283f0d20742b64968d44825617aa6717b07c006168ed16488804",
-                "sha256:91422ba785a8e7a18725b1dc40fbd88f08a5bb4c7f1b3e8739cab24b04fa8a03",
-                "sha256:9a66f4d2a005bc78e61d805ed95dedfcb35efa84b7bba0403c6d60d13a3de2d6",
-                "sha256:9b106bc52e7f28170e624ba61cc7dc6829566e535a6ec68528f8e1afbed1c41f",
-                "sha256:9b54577032d4f235452f77a83169b6527bf4b77d73aeada97d45b2aaf1bf5ce0",
-                "sha256:a09506eb48fa5493c58f946c46754ef22f3ec0df64f2b5149373ff31fb67f3dd",
-                "sha256:a212e5dea1a4182e40cd3e4067ee46be9d10418092ce3627475e995cca95de21",
-                "sha256:a731ac5cffc34dac62053e0da90f0c0b8560396a19f69d9703e88240c8f05858",
-                "sha256:af5ef6cfaf0d023c00002ba25d0751e5995fa0e4c9eec6cd263c30352662cbce",
-                "sha256:b58b855d0071575ea9c7bc0d84a06d2edfbfccec52e9657864386381a7ce1ae9",
-                "sha256:bc808924470643b82b14fe121923c30ec211d8c693e747eba8a7414bc4351a23",
-                "sha256:c557e94e91a983e5b1e9c60076a8fd79fea1e7e06848eb2e48d0ccfb30f6e073",
-                "sha256:c71be3f86d67d8d1311c6076a4ba3b75ba5703c0b856b4e691c9097f9b1e8bd2",
-                "sha256:c8754c75f55781515a3005063d9a05878b2cfb3cb7e41d5401ad0cf19de14872",
-                "sha256:cb0af13433dbbd1c806e671d81ec75bd324af6ef75171fd7815ca3074fe32bfe",
-                "sha256:cba6209c96828711cb7c8fcb45ecef8c8859238baf15119daa1bef0f6c84bfe7",
-                "sha256:cf77f8cf2a651fbd869fbdcb4a1931464189cd210abc4cfad357f1cacc8642a6",
-                "sha256:d7404cebcdb11bb5bd40bf94131faf7e9a7c10a6c60358580fe83913f360f929",
-                "sha256:dd1d3a8d1d2e50ad9b59e10aa7f07c7d1be2b367f3f2d33c5fade96ed5460962",
-                "sha256:e5d97c65ea7e097056f3d1ead77040ebc236feaf7f71489383d20f3b4c28412a",
-                "sha256:f1c3dc536b3ee124e8b24feb7533e5c70b9f2ef833e3b2e5513b2897fd46763a",
-                "sha256:f2212796593ad1d0235068c79836861f2201fc7137a99aa2fea7beeb3b101177",
-                "sha256:fead980fbc68512dfd4e0c7b1f5754c2a8e5015a04dea454b9cada54a8423525"
+                "sha256:12859468e8918d3bd243d213cd6fd6ab07208195dc140763c00dfe901ce1e1b4",
+                "sha256:1714e7bc935780bc3de1b3fcbc7674209adf5208ff825799d579ffd6cd0bd505",
+                "sha256:179bee6f5ed7b5f618844f760b6acf7e910988de77a4f75b95bbfaa8106f3c1e",
+                "sha256:1f1e7b36bdff50103af95a80923bf1853f6823dd62f2d2a2524b66ed74103e49",
+                "sha256:1faa02530b6c7426404372515fe5ddf66e199c2ee613f88f025c6f3bd816450c",
+                "sha256:22bccdd7b23c420a27fd28540fb5dcbc97dc6be105f7698cb0e7d7a420d0e362",
+                "sha256:23e2e04b83f347d0aadde0c9b616f4726c3d76db04b438fd3904b289a725267f",
+                "sha256:3227c667dccbe38f2c4d943238b887bac588d97c104815aecc62d2fd976e014b",
+                "sha256:359f821d4578f80f41909b9ee9b76fb249a21035a061a327f91c953493782c31",
+                "sha256:3952b581eb121324853ce2b191dae08badb75cd493cb4e0243368aa9e61cfd41",
+                "sha256:407b26b7f7bbd4f4751dbc9767a1f0716f9fe72d3d7e96bb3ccfc4aace07c8de",
+                "sha256:4187201a53f8561c015bc745b81a1b2d278967b8de35f3399b84b0695e281d5f",
+                "sha256:482ae2ae78679ba9ed5752099b32e5fe580443b4f798e1b71df412abf43375db",
+                "sha256:48611e4fa010e823ba2de8fd3f77c1322dd60cb0d180dc6630a7e157b205f7ea",
+                "sha256:48f7135c3de2f298b833be8b4ae20cafe37091634e91f61f5a7eb3d61ec6f660",
+                "sha256:4b49fd8fe9f9ac23b78437da94c54aa7e9996fbb220bac024a67469ce5d0825f",
+                "sha256:58f6c693d446964e3292425e1d16e21a97a48ba9172f2d0df9d7b640acb99243",
+                "sha256:5bd90b8c395f39bc82a5fb32a0173e220e3f401ff697840f4003e15b96d1befc",
+                "sha256:60dcd824df166ba266ee0cfaf35a31406cd16ef602b49f5d4dfb21f014b0dedd",
+                "sha256:6696ffe440333a19d8d128e88d440f91fb92c75a80ce4b44d55800e656a3ef1d",
+                "sha256:6c455e008fa86d9e9a9d85bb76da4277c0d7d9668a3bfa70dbe86e9f3c759947",
+                "sha256:71f11fd63365ade276c9d4a7b7df5c136f9030e3457107e1791b3737a9b9ed6a",
+                "sha256:73db2dc1b201d20ab7083e7041946910bb991e7e9761a0394bbc3c2632326483",
+                "sha256:77c339403db5a20ef4fed02e4d1a9a3d9866bf9c0afc77a42234677313ea22f3",
+                "sha256:833379943d1728a005e44103f17ecd73d058d37d95783eb8f0b28ddc1f54d7b2",
+                "sha256:83a17b303425104d6329c10eb34bba186ffa67161e63fa6cdae7776ff76df73f",
+                "sha256:83e7ccb85a74beaeae2634f10eb858a0ed1a63081172649ff4261f929bacfd22",
+                "sha256:844d1f3fb11bd1ed362d3fdc495d0770cfab75761836193af166fee113421d66",
+                "sha256:882020c87999d54667a284c7ddf065b359bd00251fcd70279ac486776dbf84ec",
+                "sha256:8999bf1b57172dbc7c3e4bb3c732658e918f5c333b2942243f10d0d653953ba9",
+                "sha256:9084086190cc6d628f282e5615f987288b95457292e969b9205e45b442276407",
+                "sha256:960edebedc6b9ada1ef58e1c71156f28689978188cd8cff3b646b57288a927d9",
+                "sha256:973c49086cabab773525f6077f95e5a993bfc03ba8fc32e32f2c279497780585",
+                "sha256:978121758711916d34fe57c1f75b79cdfc73952f1481bb9583399331682d36f7",
+                "sha256:9bd5c8a1af40ec305d001c60236308a67e25419003e9bb3ebfab5695a8d0b369",
+                "sha256:a10383035e864f386fe096fed5c47d27a2bf7173c56a6e26cffaaa5a361addb1",
+                "sha256:a485f0c2010c696be269184bdb5ae72781344cb4e60db976c59d84dd6354fac9",
+                "sha256:a7f615270fe534548112a74e790cd9d4f5509d744dd718cd442bf016626c22e4",
+                "sha256:b134d5d71b4e0837fff574c00e49176051a1c532d26c052a1e43231f252d813b",
+                "sha256:b2a0e71b0a2158aa4bce48be9f8f9eb45cbd17c78c7443616d00abbe2a509f6d",
+                "sha256:b50b09b4dc01767163d67e1532f948264167cd27f49e9377e3556c3cba1268e1",
+                "sha256:b5a4ea906db7dec694098435d84bf2854fe158eb3cd51e1107e571246d4d1d70",
+                "sha256:b7209117bbeebdfa5d898205cc55153a51285757902dd73c47de498ad4d11332",
+                "sha256:bba97b8e8883a8038606480d6b6772289f4c907f6ba780fa1f7b7da7dfd76f06",
+                "sha256:be0477cb31da67846a33b1a75c611f88bfbcd427fe17701b6317aefceee1b96f",
+                "sha256:c7fcc6a32e7b7b58f5a7d27530669337a5d587d4066060bcb9dee7a8c833dfb7",
+                "sha256:c8842ccbd8c0e253c1f189088228f9b433f7a93b7196b9e5b6f87dba393f5d5d",
+                "sha256:d1f6c96573dc09d50dbcbd91dbf71d5cf97640c9427c32584010fbbd4c0e0037",
+                "sha256:d9e52558b8b8c2f4ac05ac86344a7417ccdd2b460a59616de49eb6933b07a0bd",
+                "sha256:e3393b0823f938253370ebef033c9fd23d27f3eae8eb9a8f6264900c7ea3fb5a",
+                "sha256:e6c8c8693df718c5ecbc7babb12c69a4e3677fd11de8886f05ab22d4e6b1c43b",
+                "sha256:f8de7c8cef9261a2d0a62edf2ccea3d741a523c6b8a6477a340a1f2e417658de",
+                "sha256:fa7d28eb4d50b7cbe75bb8b45ed0da9a1dc5b219a0af59449676a29c2eed9698",
+                "sha256:fbe80577c7880911d3ad65e5ecc997416c98f354efeba2f8d0f9112a67ed65a5"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.60.1"
+            "version": "==1.62.1"
         },
         "grpcio-status": {
             "hashes": [
-                "sha256:3034fdb239185b6e0f3169d08c268c4507481e4b8a434c21311a03d9eb5889a0",
-                "sha256:61b5aab8989498e8aa142c20b88829ea5d90d18c18c853b9f9e6d407d37bf8b4"
+                "sha256:3431c8abbab0054912c41df5c72f03ddf3b7a67be8a287bb3c18a3456f96ff77",
+                "sha256:af0c3ab85da31669f21749e8d53d669c061ebc6ce5637be49a46edcb7aa8ab17"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.60.1"
+            "version": "==1.62.1"
         },
         "h11": {
             "hashes": [
@@ -514,11 +506,12 @@
         },
         "jwcrypto": {
             "hashes": [
-                "sha256:48bb9bf433777136253579e52b75ffe0f9a4a721d133d01f45a0b91ed5f4f1ae"
+                "sha256:150d2b0ebbdb8f40b77f543fb44ffd2baeff48788be71f67f03566692fd55789",
+                "sha256:771a87762a0c081ae6166958a954f80848820b2ab066937dc8b8379d65b1b039"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==1.5.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.6"
         },
         "outcome": {
             "hashes": [
@@ -570,20 +563,20 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:10894a2885b7175d3984f2be8d9850712c57d5e7587a2410720af8be56cdaf62",
-                "sha256:2db9f8fa64fbdcdc93767d3cf81e0f2aef176284071507e3ede160811502fd3d",
-                "sha256:33a1aeef4b1927431d1be780e87b641e322b88d654203a9e9d93f218ee359e61",
-                "sha256:47f3de503fe7c1245f6f03bea7e8d3ec11c6c4a2ea9ef910e3221c8a15516d62",
-                "sha256:5e5c933b4c30a988b52e0b7c02641760a5ba046edc5e43d3b94a74c9fc57c1b3",
-                "sha256:8f62574857ee1de9f770baf04dde4165e30b15ad97ba03ceac65f760ff018ac9",
-                "sha256:a8b7a98d4ce823303145bf3c1a8bdb0f2f4642a414b196f04ad9853ed0c8f830",
-                "sha256:b50c949608682b12efb0b2717f53256f03636af5f60ac0c1d900df6213910fd6",
-                "sha256:d66a769b8d687df9024f2985d5137a337f957a0916cf5464d1513eee96a63ff0",
-                "sha256:fc381d1dd0516343f1440019cedf08a7405f791cd49eef4ae1ea06520bc1c020",
-                "sha256:fe599e175cb347efc8ee524bcd4b902d11f7262c0e569ececcb89995c15f0a5e"
+                "sha256:19b270aeaa0099f16d3ca02628546b8baefe2955bbe23224aaf856134eccf1e4",
+                "sha256:209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8",
+                "sha256:25b5d0b42fd000320bd7830b349e3b696435f3b329810427a6bcce6a5492cc5c",
+                "sha256:7c8daa26095f82482307bc717364e7c13f4f1c99659be82890dcfc215194554d",
+                "sha256:c053062984e61144385022e53678fbded7aea14ebb3e0305ae3592fb219ccfa4",
+                "sha256:d4198877797a83cbfe9bffa3803602bbe1625dc30d8a097365dbc762e5790faa",
+                "sha256:e3c97a1555fd6388f857770ff8b9703083de6bf1f9274a002a332d65fbb56c8c",
+                "sha256:e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019",
+                "sha256:f0700d54bcf45424477e46a9f0944155b46fb0639d69728739c0e47bab83f2b9",
+                "sha256:f1279ab38ecbfae7e456a108c5c0681e4956d5b1090027c1de0f934dfdb4b35c",
+                "sha256:f4f118245c4a087776e0a8408be33cf09f6c547442c00395fbfb116fac2f8ac2"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.25.2"
+            "version": "==4.25.3"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -666,26 +659,27 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:4439847c58d40b1d0a573d07e3856e95333f1976294494c325775aeca506eb58",
-                "sha256:6d391a96e59b23130a5cfa74d6fd7f388dbbe26cc8f1edf39fdddf08d9d6676c"
+                "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c",
+                "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.5.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.6.0"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c",
-                "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"
+                "sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6",
+                "sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==0.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==0.4.0"
         },
         "pycparser": {
             "hashes": [
-                "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9",
-                "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+                "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+                "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"
             ],
-            "version": "==2.21"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.22"
         },
         "pynacl": {
             "hashes": [
@@ -754,11 +748,11 @@
         },
         "sniffio": {
             "hashes": [
-                "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101",
-                "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"
+                "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+                "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.3.0"
+            "version": "==1.3.1"
         },
         "sortedcontainers": {
             "hashes": [
@@ -797,11 +791,11 @@
         },
         "trio": {
             "hashes": [
-                "sha256:c3bd3a4e3e3025cd9a2241eae75637c43fe0b9e88b4c97b9161a55b9e54cd72c",
-                "sha256:ffa09a74a6bf81b84f8613909fb0beaee84757450183a7a2e0b47b455c0cac5d"
+                "sha256:9b41f5993ad2c0e5f62d0acca320ec657fdb6b2a2c22b8c7aed6caf154475c4e",
+                "sha256:e6458efe29cc543e557a91e614e2b51710eba2961669329ce9c862d50c6e8e81"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.24.0"
+            "version": "==0.25.0"
         },
         "trio-websocket": {
             "hashes": [
@@ -811,92 +805,24 @@
             "markers": "python_version >= '3.7'",
             "version": "==0.11.1"
         },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
+                "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.10.0"
+        },
         "urllib3": {
             "extras": [
                 "socks"
             ],
             "hashes": [
-                "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
-                "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
+                "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d",
+                "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.0"
-        },
-        "wrapt": {
-            "hashes": [
-                "sha256:0d2691979e93d06a95a26257adb7bfd0c93818e89b1406f5a28f36e0d8c1e1fc",
-                "sha256:14d7dc606219cdd7405133c713f2c218d4252f2a469003f8c46bb92d5d095d81",
-                "sha256:1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09",
-                "sha256:1acd723ee2a8826f3d53910255643e33673e1d11db84ce5880675954183ec47e",
-                "sha256:1ca9b6085e4f866bd584fb135a041bfc32cab916e69f714a7d1d397f8c4891ca",
-                "sha256:1dd50a2696ff89f57bd8847647a1c363b687d3d796dc30d4dd4a9d1689a706f0",
-                "sha256:2076fad65c6736184e77d7d4729b63a6d1ae0b70da4868adeec40989858eb3fb",
-                "sha256:2a88e6010048489cda82b1326889ec075a8c856c2e6a256072b28eaee3ccf487",
-                "sha256:3ebf019be5c09d400cf7b024aa52b1f3aeebeff51550d007e92c3c1c4afc2a40",
-                "sha256:418abb18146475c310d7a6dc71143d6f7adec5b004ac9ce08dc7a34e2babdc5c",
-                "sha256:43aa59eadec7890d9958748db829df269f0368521ba6dc68cc172d5d03ed8060",
-                "sha256:44a2754372e32ab315734c6c73b24351d06e77ffff6ae27d2ecf14cf3d229202",
-                "sha256:490b0ee15c1a55be9c1bd8609b8cecd60e325f0575fc98f50058eae366e01f41",
-                "sha256:49aac49dc4782cb04f58986e81ea0b4768e4ff197b57324dcbd7699c5dfb40b9",
-                "sha256:5eb404d89131ec9b4f748fa5cfb5346802e5ee8836f57d516576e61f304f3b7b",
-                "sha256:5f15814a33e42b04e3de432e573aa557f9f0f56458745c2074952f564c50e664",
-                "sha256:5f370f952971e7d17c7d1ead40e49f32345a7f7a5373571ef44d800d06b1899d",
-                "sha256:66027d667efe95cc4fa945af59f92c5a02c6f5bb6012bff9e60542c74c75c362",
-                "sha256:66dfbaa7cfa3eb707bbfcd46dab2bc6207b005cbc9caa2199bcbc81d95071a00",
-                "sha256:685f568fa5e627e93f3b52fda002c7ed2fa1800b50ce51f6ed1d572d8ab3e7fc",
-                "sha256:6906c4100a8fcbf2fa735f6059214bb13b97f75b1a61777fcf6432121ef12ef1",
-                "sha256:6a42cd0cfa8ffc1915aef79cb4284f6383d8a3e9dcca70c445dcfdd639d51267",
-                "sha256:6dcfcffe73710be01d90cae08c3e548d90932d37b39ef83969ae135d36ef3956",
-                "sha256:6f6eac2360f2d543cc875a0e5efd413b6cbd483cb3ad7ebf888884a6e0d2e966",
-                "sha256:72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1",
-                "sha256:73870c364c11f03ed072dda68ff7aea6d2a3a5c3fe250d917a429c7432e15228",
-                "sha256:73aa7d98215d39b8455f103de64391cb79dfcad601701a3aa0dddacf74911d72",
-                "sha256:75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d",
-                "sha256:7bd2d7ff69a2cac767fbf7a2b206add2e9a210e57947dd7ce03e25d03d2de292",
-                "sha256:807cc8543a477ab7422f1120a217054f958a66ef7314f76dd9e77d3f02cdccd0",
-                "sha256:8e9723528b9f787dc59168369e42ae1c3b0d3fadb2f1a71de14531d321ee05b0",
-                "sha256:9090c9e676d5236a6948330e83cb89969f433b1943a558968f659ead07cb3b36",
-                "sha256:9153ed35fc5e4fa3b2fe97bddaa7cbec0ed22412b85bcdaf54aeba92ea37428c",
-                "sha256:9159485323798c8dc530a224bd3ffcf76659319ccc7bbd52e01e73bd0241a0c5",
-                "sha256:941988b89b4fd6b41c3f0bfb20e92bd23746579736b7343283297c4c8cbae68f",
-                "sha256:94265b00870aa407bd0cbcfd536f17ecde43b94fb8d228560a1e9d3041462d73",
-                "sha256:98b5e1f498a8ca1858a1cdbffb023bfd954da4e3fa2c0cb5853d40014557248b",
-                "sha256:9b201ae332c3637a42f02d1045e1d0cccfdc41f1f2f801dafbaa7e9b4797bfc2",
-                "sha256:a0ea261ce52b5952bf669684a251a66df239ec6d441ccb59ec7afa882265d593",
-                "sha256:a33a747400b94b6d6b8a165e4480264a64a78c8a4c734b62136062e9a248dd39",
-                "sha256:a452f9ca3e3267cd4d0fcf2edd0d035b1934ac2bd7e0e57ac91ad6b95c0c6389",
-                "sha256:a86373cf37cd7764f2201b76496aba58a52e76dedfaa698ef9e9688bfd9e41cf",
-                "sha256:ac83a914ebaf589b69f7d0a1277602ff494e21f4c2f743313414378f8f50a4cf",
-                "sha256:aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89",
-                "sha256:b3646eefa23daeba62643a58aac816945cadc0afaf21800a1421eeba5f6cfb9c",
-                "sha256:b47cfad9e9bbbed2339081f4e346c93ecd7ab504299403320bf85f7f85c7d46c",
-                "sha256:b935ae30c6e7400022b50f8d359c03ed233d45b725cfdd299462f41ee5ffba6f",
-                "sha256:bb2dee3874a500de01c93d5c71415fcaef1d858370d405824783e7a8ef5db440",
-                "sha256:bc57efac2da352a51cc4658878a68d2b1b67dbe9d33c36cb826ca449d80a8465",
-                "sha256:bf5703fdeb350e36885f2875d853ce13172ae281c56e509f4e6eca049bdfb136",
-                "sha256:c31f72b1b6624c9d863fc095da460802f43a7c6868c5dda140f51da24fd47d7b",
-                "sha256:c5cd603b575ebceca7da5a3a251e69561bec509e0b46e4993e1cac402b7247b8",
-                "sha256:d2efee35b4b0a347e0d99d28e884dfd82797852d62fcd7ebdeee26f3ceb72cf3",
-                "sha256:d462f28826f4657968ae51d2181a074dfe03c200d6131690b7d65d55b0f360f8",
-                "sha256:d5e49454f19ef621089e204f862388d29e6e8d8b162efce05208913dde5b9ad6",
-                "sha256:da4813f751142436b075ed7aa012a8778aa43a99f7b36afe9b742d3ed8bdc95e",
-                "sha256:db2e408d983b0e61e238cf579c09ef7020560441906ca990fe8412153e3b291f",
-                "sha256:db98ad84a55eb09b3c32a96c576476777e87c520a34e2519d3e59c44710c002c",
-                "sha256:dbed418ba5c3dce92619656802cc5355cb679e58d0d89b50f116e4a9d5a9603e",
-                "sha256:dcdba5c86e368442528f7060039eda390cc4091bfd1dca41e8046af7c910dda8",
-                "sha256:decbfa2f618fa8ed81c95ee18a387ff973143c656ef800c9f24fb7e9c16054e2",
-                "sha256:e4fdb9275308292e880dcbeb12546df7f3e0f96c6b41197e0cf37d2826359020",
-                "sha256:eb1b046be06b0fce7249f1d025cd359b4b80fc1c3e24ad9eca33e0dcdb2e4a35",
-                "sha256:eb6e651000a19c96f452c85132811d25e9264d836951022d6e81df2fff38337d",
-                "sha256:ed867c42c268f876097248e05b6117a65bcd1e63b779e916fe2e33cd6fd0d3c3",
-                "sha256:edfad1d29c73f9b863ebe7082ae9321374ccb10879eeabc84ba3b69f2579d537",
-                "sha256:f2058f813d4f2b5e3a9eb2eb3faf8f1d99b81c3e51aeda4b168406443e8ba809",
-                "sha256:f6b2d0c6703c988d334f297aa5df18c45e97b0af3679bb75059e0e0bd8b1069d",
-                "sha256:f8212564d49c50eb4565e502814f694e240c55551a5f1bc841d4fcaabb0a9b8a",
-                "sha256:ffa565331890b90056c01db69c0fe634a776f8019c143a5ae265f9c6bc4bd6d4"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.16.0"
+            "version": "==2.2.1"
         },
         "wsproto": {
             "hashes": [

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -43,7 +43,7 @@ def before_all(context):
 
 def move_fulfilment_triggers_harmlessly_massively_into_the_future():
     # The year 3000 ought to be far enough in the future for this fulfilment to never trigger again, no?
-    url = f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers/?triggerDateTime=3000-01-01T00:00:00.000Z'
+    url = f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers?triggerDateTime=3000-01-01T00:00:00.000Z'
     response = iap_requests.make_request(method='POST', url=url)
     response.raise_for_status()
 

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -11,6 +11,7 @@ from selenium.webdriver.chrome.options import Options
 from splinter import Browser
 from structlog import wrap_logger
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.audit_trail_helper import log_out_user_context_values, parse_markdown_context_table
 from acceptance_tests.utilities.eq_stub_helper import reset_eq_stub
 from acceptance_tests.utilities.exception_manager_helper import get_bad_messages, \
@@ -42,9 +43,13 @@ def before_all(context):
 
 def move_fulfilment_triggers_harmlessly_massively_into_the_future():
     # The year 3000 ought to be far enough in the future for this fulfilment to never trigger again, no?
-    url = f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers?triggerDateTime=3000-01-01T00:00:00.000Z'
-
-    response = requests.post(url)
+    url = f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers/?triggerDateTime=3000-01-01T00:00:00.000Z'
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST')
+    else:
+        response = requests.post(url)
     response.raise_for_status()
 
 

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -44,12 +44,7 @@ def before_all(context):
 def move_fulfilment_triggers_harmlessly_massively_into_the_future():
     # The year 3000 ought to be far enough in the future for this fulfilment to never trigger again, no?
     url = f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers/?triggerDateTime=3000-01-01T00:00:00.000Z'
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST')
-    else:
-        response = requests.post(url)
+    response = iap_requests.make_request(method='POST', url=url)
     response.raise_for_status()
 
 

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -3,6 +3,7 @@ import uuid
 import requests
 from behave import step
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_email_fulfilment_response
@@ -22,7 +23,13 @@ def authorise_sms_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)
@@ -63,7 +70,13 @@ def request_replacement_uac_by_email(context, email, personalisation=None):
     if personalisation:
         context.fulfilment_personalisation = body['payload']['emailFulfilment']['personalisation'] = personalisation
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
     response.raise_for_status()
 
     context.fulfilment_response_json = response.json()

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -23,13 +23,7 @@ def authorise_sms_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)
@@ -70,13 +64,7 @@ def request_replacement_uac_by_email(context, email, personalisation=None):
     if personalisation:
         context.fulfilment_personalisation = body['payload']['emailFulfilment']['personalisation'] = personalisation
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     context.fulfilment_response_json = response.json()

--- a/acceptance_tests/features/steps/email_fulfilment.py
+++ b/acceptance_tests/features/steps/email_fulfilment.py
@@ -1,6 +1,5 @@
 import uuid
 
-import requests
 from behave import step
 
 from acceptance_tests.utilities import iap_requests

--- a/acceptance_tests/features/steps/invalid_case.py
+++ b/acceptance_tests/features/steps/invalid_case.py
@@ -77,4 +77,5 @@ def bulk_invalid_file_created_and_uploaded(context):
         for case_id, reason in context.bulk_invalids.items():
             writer.writerow({'caseId': case_id, 'reason': reason})
 
-    upload_and_process_file_by_api(context.collex_id, bulk_invalid_filename, job_type='BULK_INVALID', delete_after_upload=True)
+    upload_and_process_file_by_api(context.collex_id, bulk_invalid_filename, job_type='BULK_INVALID',
+                                   delete_after_upload=True)

--- a/acceptance_tests/features/steps/invalid_case.py
+++ b/acceptance_tests/features/steps/invalid_case.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from behave import step
 
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
-from acceptance_tests.utilities.file_to_process_upload_helper import upload_file_via_api
+from acceptance_tests.utilities.file_to_process_upload_helper import upload_and_process_file_by_api
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -77,4 +77,4 @@ def bulk_invalid_file_created_and_uploaded(context):
         for case_id, reason in context.bulk_invalids.items():
             writer.writerow({'caseId': case_id, 'reason': reason})
 
-    upload_file_via_api(context.collex_id, bulk_invalid_filename, job_type='BULK_INVALID', delete_after_upload=True)
+    upload_and_process_file_by_api(context.collex_id, bulk_invalid_filename, job_type='BULK_INVALID', delete_after_upload=True)

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -52,12 +52,7 @@ def print_fulfilments_trigger_step(context):
     url = (f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers'
            f'?triggerDateTime={datetime.utcnow().replace(microsecond=0).isoformat()}Z')
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST')
-    else:
-        response = requests.post(url)
+    response = iap_requests.make_request(method='POST', url=url)
     response.raise_for_status()
 
 
@@ -72,13 +67,7 @@ def authorise_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -2,7 +2,6 @@ import json
 import uuid
 from datetime import datetime
 
-import requests
 from behave import step
 
 from acceptance_tests.utilities import iap_requests

--- a/acceptance_tests/features/steps/print_fulfilment.py
+++ b/acceptance_tests/features/steps/print_fulfilment.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import requests
 from behave import step
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
@@ -51,7 +52,12 @@ def print_fulfilments_trigger_step(context):
     url = (f'{Config.SUPPORT_TOOL_API}/fulfilmentNextTriggers'
            f'?triggerDateTime={datetime.utcnow().replace(microsecond=0).isoformat()}Z')
 
-    response = requests.post(url)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST')
+    else:
+        response = requests.post(url)
     response.raise_for_status()
 
 
@@ -66,7 +72,13 @@ def authorise_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from behave import step
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
-from acceptance_tests.utilities.file_to_process_upload_helper import upload_file_via_api
+from acceptance_tests.utilities.file_to_process_upload_helper import upload_and_process_file_by_api
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -78,4 +78,4 @@ def create_and_upload_bulk_refusal_file(context):
         for case_id, refusal_type in context.bulk_refusals.items():
             writer.writerow({'caseId': case_id, 'refusalType': refusal_type})
 
-    upload_file_via_api(context.collex_id, bulk_refusals_file, 'BULK_REFUSAL')
+    upload_and_process_file_by_api(context.collex_id, bulk_refusals_file, 'BULK_REFUSAL')

--- a/acceptance_tests/features/steps/sample_data.py
+++ b/acceptance_tests/features/steps/sample_data.py
@@ -11,7 +11,7 @@ from tenacity import retry, stop_after_delay, wait_fixed
 
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 from acceptance_tests.utilities.database_helper import open_cursor
-from acceptance_tests.utilities.file_to_process_upload_helper import upload_file_via_api
+from acceptance_tests.utilities.file_to_process_upload_helper import upload_and_process_file_by_api
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -103,5 +103,5 @@ def create_and_upload_sample_update_file(context):
             writer.writerow({'caseId': case_row['caseId'], 'fieldToUpdate': case_row['fieldToUpdate'],
                              'newValue': case_row['newValue']})
 
-    upload_file_via_api(context.collex_id, bulk_sample_update_filename, job_type='BULK_UPDATE_SAMPLE',
-                        delete_after_upload=True)
+    upload_and_process_file_by_api(context.collex_id, bulk_sample_update_filename, job_type='BULK_UPDATE_SAMPLE',
+                                   delete_after_upload=True)

--- a/acceptance_tests/features/steps/sample_loading.py
+++ b/acceptance_tests/features/steps/sample_loading.py
@@ -8,7 +8,7 @@ from behave import step
 
 from acceptance_tests.utilities.collex_helper import add_collex
 from acceptance_tests.utilities.event_helper import get_emitted_cases
-from acceptance_tests.utilities.file_to_process_upload_helper import upload_file_via_api
+from acceptance_tests.utilities.file_to_process_upload_helper import upload_and_process_file_by_api
 from acceptance_tests.utilities.sample_helper import read_sample
 from acceptance_tests.utilities.survey_helper import add_survey
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -83,7 +83,7 @@ def load_bom_sample_file_step(context, sample_file_name):
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
@@ -116,7 +116,7 @@ def load_sample_with_survey_type(context, sample_file_name, survey_type):
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
@@ -148,7 +148,7 @@ def load_sample_file_with_complex_case_ci_rules_step(context, sample_file_name):
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
@@ -185,7 +185,7 @@ def load_sample_file_with_complex_uac_ci_rules_step(context, sample_file_name):
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
@@ -215,7 +215,7 @@ def load_sample_file_with_validation_rules_step(context, sample_file_name, valid
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.sample = read_sample(sample_file_path, sample_validation_rules)
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,
@@ -281,7 +281,7 @@ def load_business_sample_file_step(context):
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime)
 
@@ -308,7 +308,7 @@ def load_sample_file_step_for_sensitive_data_multi_column(context, sample_file_n
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,
                                                                        sensitive_columns)
@@ -345,7 +345,7 @@ def load_sample_with_rules_and_eq_launch_settings(context, sample_file_name, val
                                    context.test_start_utc_datetime, collection_exercise_start_date,
                                    context.collex_end_date)
 
-    upload_file_via_api(context.collex_id, sample_file_path, 'SAMPLE')
+    upload_and_process_file_by_api(context.collex_id, sample_file_path, 'SAMPLE')
 
     context.sample = read_sample(sample_file_path, sample_validation_rules)
     context.emitted_cases = get_emitted_cases_and_check_against_sample(sample_rows, context.test_start_utc_datetime,

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -110,7 +110,8 @@ def create_and_upload_sensitive_update_file(context):
             writer.writerow({'caseId': case_row['caseId'], 'fieldToUpdate': case_row['fieldToUpdate'],
                              'newValue': case_row['newValue']})
 
-    upload_and_process_file_by_api(context.collex_id, bulk_sensitive_update_filename, job_type='BULK_UPDATE_SAMPLE_SENSITIVE',
+    upload_and_process_file_by_api(context.collex_id, bulk_sensitive_update_filename,
+                                   job_type='BULK_UPDATE_SAMPLE_SENSITIVE',
                                    delete_after_upload=True)
 
 

--- a/acceptance_tests/features/steps/sensitive_data.py
+++ b/acceptance_tests/features/steps/sensitive_data.py
@@ -12,7 +12,7 @@ from tenacity import retry, wait_fixed, stop_after_delay
 from acceptance_tests.utilities.audit_trail_helper import add_random_suffix_to_email
 from acceptance_tests.utilities.database_helper import open_cursor
 from acceptance_tests.utilities.event_helper import get_emitted_cases
-from acceptance_tests.utilities.file_to_process_upload_helper import upload_file_via_api
+from acceptance_tests.utilities.file_to_process_upload_helper import upload_and_process_file_by_api
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -110,8 +110,8 @@ def create_and_upload_sensitive_update_file(context):
             writer.writerow({'caseId': case_row['caseId'], 'fieldToUpdate': case_row['fieldToUpdate'],
                              'newValue': case_row['newValue']})
 
-    upload_file_via_api(context.collex_id, bulk_sensitive_update_filename, job_type='BULK_UPDATE_SAMPLE_SENSITIVE',
-                        delete_after_upload=True)
+    upload_and_process_file_by_api(context.collex_id, bulk_sensitive_update_filename, job_type='BULK_UPDATE_SAMPLE_SENSITIVE',
+                                   delete_after_upload=True)
 
 
 @step("in the database the sensitive data has been updated as expected and is emitted redacted")

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -3,6 +3,7 @@ import uuid
 import requests
 from behave import step
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.audit_trail_helper import get_unique_user_email
 from acceptance_tests.utilities.event_helper import get_emitted_survey_update_by_id
 from acceptance_tests.utilities.notify_helper import check_sms_fulfilment_response
@@ -22,7 +23,13 @@ def authorise_sms_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/sms_fulfilment.py
+++ b/acceptance_tests/features/steps/sms_fulfilment.py
@@ -23,13 +23,7 @@ def authorise_sms_pack_code(context, template_name):
         'packCode': context.pack_code
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     survey_update_event = get_emitted_survey_update_by_id(context.survey_id, context.test_start_utc_datetime)

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -24,7 +24,7 @@ from selenium.webdriver.support import expected_conditions as EC
 
 @step("the support tool landing page is displayed")
 def navigate_to_support_tool_landing_page(context):
-    context.browser.visit(f'{Config.SUPPORT_TOOL_URL}')
+    context.browser.visit(f'{Config.SUPPORT_TOOL_UI_URL}')
 
 
 @step("the Create Survey Button is clicked on")

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -35,7 +35,7 @@ def click_on_create_survey_button(context):
 @step(
     'a Survey called "{survey_prefix}" plus unique suffix is created for sample file "{sample_file_name}" '
     'with sensitive columns {sensitive_columns:array}')
-def create_survey_in_UI(context, survey_prefix, sample_file_name, sensitive_columns):
+def create_survey_in_ui(context, survey_prefix, sample_file_name, sensitive_columns):
     context.survey_name = survey_prefix + get_random_alpha_numerics(5)
     context.browser.find_by_id('surveyNameTextField').fill(context.survey_name)
 
@@ -107,7 +107,8 @@ def click_load_sample(context, sample_file_name):
     context.browser.find_by_id("jobProcessBtn", wait_time=30).click()
     poll_sample_status_processed(context.browser)
     context.browser.find_by_id('closeSampledetailsBtn').click()
-    context.emitted_cases = get_emitted_cases(context.sample_count, context.test_start_utc_datetime)
+    context.emitted_cases = get_emitted_cases(context.sample_count, context.test_start_utc_datetime,
+                                              originating_user_email=Config.UI_USER_EMAIL)
 
     test_helper.assertEquals(len(context.emitted_cases), context.sample_count)
 

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -49,7 +49,7 @@ def setup_sms_action_rule(collex_id, pack_code):
         'uacMetadata': {"waveOfContact": "1"}
     }
 
-    response = iap_requests.make_iap_request(method='POST', url=ACTION_RULES_URL, json=body)
+    response = iap_requests.make_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -17,13 +17,7 @@ def create_export_file_action_rule(collex_id, classifiers, pack_code):
         'collectionExerciseId': collex_id
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(ACTION_RULES_URL,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(ACTION_RULES_URL, json=body)
+    response = iap_requests.make_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -38,13 +32,7 @@ def setup_deactivate_uac_action_rule(collex_id):
         'collectionExerciseId': collex_id
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(ACTION_RULES_URL,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(ACTION_RULES_URL, json=body)
+    response = iap_requests.make_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -61,13 +49,7 @@ def setup_sms_action_rule(collex_id, pack_code):
         'uacMetadata': {"waveOfContact": "1"}
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(ACTION_RULES_URL,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(ACTION_RULES_URL, json=body)
+    response = iap_requests.make_iap_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -84,13 +66,7 @@ def setup_email_action_rule(collex_id, pack_code):
         'uacMetadata': {"waveOfContact": "1"}
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(ACTION_RULES_URL,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(ACTION_RULES_URL, json=body)
+    response = iap_requests.make_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -105,11 +81,5 @@ def set_eq_flush_action_rule(collex_id):
         'collectionExerciseId': collex_id,
     }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(ACTION_RULES_URL,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(ACTION_RULES_URL, json=body)
+    response = iap_requests.make_request(method='POST', url=ACTION_RULES_URL, json=body)
     response.raise_for_status()

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-import requests
-
 from acceptance_tests.utilities import iap_requests
 from config import Config
 

--- a/acceptance_tests/utilities/action_rule_helper.py
+++ b/acceptance_tests/utilities/action_rule_helper.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import requests
 
+from acceptance_tests.utilities import iap_requests
 from config import Config
 
 ACTION_RULES_URL = f'{Config.SUPPORT_TOOL_API}/actionRules'
@@ -16,7 +17,13 @@ def create_export_file_action_rule(collex_id, classifiers, pack_code):
         'collectionExerciseId': collex_id
     }
 
-    response = requests.post(ACTION_RULES_URL, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(ACTION_RULES_URL,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -31,7 +38,13 @@ def setup_deactivate_uac_action_rule(collex_id):
         'collectionExerciseId': collex_id
     }
 
-    response = requests.post(ACTION_RULES_URL, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(ACTION_RULES_URL,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -48,7 +61,13 @@ def setup_sms_action_rule(collex_id, pack_code):
         'uacMetadata': {"waveOfContact": "1"}
     }
 
-    response = requests.post(ACTION_RULES_URL, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(ACTION_RULES_URL,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -65,7 +84,13 @@ def setup_email_action_rule(collex_id, pack_code):
         'uacMetadata': {"waveOfContact": "1"}
     }
 
-    response = requests.post(ACTION_RULES_URL, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(ACTION_RULES_URL,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()
     action_rule_id = str(response.text.strip('"'))
     return action_rule_id
@@ -80,5 +105,11 @@ def set_eq_flush_action_rule(collex_id):
         'collectionExerciseId': collex_id,
     }
 
-    response = requests.post(ACTION_RULES_URL, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(ACTION_RULES_URL,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(ACTION_RULES_URL, json=body)
     response.raise_for_status()

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -1,7 +1,5 @@
 from datetime import datetime
 
-import requests
-
 from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.event_helper import get_collection_exercise_update_by_name
 from acceptance_tests.utilities.test_case_helper import test_helper

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import requests
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.event_helper import get_collection_exercise_update_by_name
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -20,7 +21,13 @@ def add_collex(survey_id, collection_instrument_selection_rules, test_start_time
             'collectionInstrumentSelectionRules': collection_instrument_selection_rules
             }
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
     response.raise_for_status()
 
     collex_id = response.json()

--- a/acceptance_tests/utilities/collex_helper.py
+++ b/acceptance_tests/utilities/collex_helper.py
@@ -21,13 +21,7 @@ def add_collex(survey_id, collection_instrument_selection_rules, test_start_time
             'collectionInstrumentSelectionRules': collection_instrument_selection_rules
             }
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     collex_id = response.json()

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -12,20 +12,21 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def get_emitted_cases(expected_msg_count=1, test_start_time: datetime = None):
+def get_emitted_cases(expected_msg_count=1, test_start_time: datetime = None,
+                      originating_user_email: str = Config.API_USER_EMAIL) -> List[Mapping]:
     messages_received = get_exact_number_of_pubsub_messages(
         Config.PUBSUB_OUTBOUND_CASE_SUBSCRIPTION, expected_msg_count, test_start_time=test_start_time)
 
     case_payloads = []
     for message_received in messages_received:
-        test_helper.assertEqual(message_received['header']['originatingUser'], Config.SAMPLE_LOAD_ORIGINATING_USER,
+        test_helper.assertEqual(message_received['header']['originatingUser'], originating_user_email,
                                 f'Unexpected originating user, all of messages_received: {messages_received}')
         case_payloads.append(message_received['payload']['caseUpdate'])
 
     return case_payloads
 
 
-def _match_message_by_correlation_id(message: Mapping, correlation_id: str = None):
+def _match_message_by_correlation_id(message: Mapping, correlation_id: str = None) -> (bool, Optional[str]):
     if (message_cid := message['header']['correlationId']) != correlation_id:
         return False, f'Message correlation ID "{message_cid}" does not match expected "{correlation_id}"'
     return True, None

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -26,6 +26,9 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
                                          data=multipart_data)
     response.raise_for_status()
 
+    # TODO debug
+    print(response.status_code, response.text)
+
     file_id = response.json()
 
     request_params = {

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -52,8 +52,8 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
         response.raise_for_status()
 
         # TODO debug
-        print(response.text)
-        
+        print(response.text[:200])
+
         if response.json().get("jobStatus") == "VALIDATED_OK":
             file_validated = True
             break

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -18,15 +18,12 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
 
     url = f'{Config.SUPPORT_TOOL_API}/upload'
 
+    # TODO fix file upload
     # response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 content_type=multipart_data.content_type,
-                                                 data=multipart_data)
-    else:
-        response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
+    response = iap_requests.make_request(method='POST',
+                                         url=url,
+                                         headers={'Content-Type': multipart_data.content_type},
+                                         data=multipart_data)
     response.raise_for_status()
 
     file_id = response.json()
@@ -39,13 +36,7 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     }
 
     create_job_url = f'{Config.SUPPORT_TOOL_API}/job'
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(create_job_url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 params=request_params)
-    else:
-        response = requests.post(create_job_url, params=request_params)
+    response = iap_requests.make_request(method='POST', url=create_job_url, params=request_params)
     response.raise_for_status()
 
     job_id = response.json()
@@ -67,13 +58,7 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
 
     if file_validated:
         process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'
-
-        if Config.IAP_CLIENT_ID:
-            response = iap_requests.make_iap_request(process_job_url,
-                                                     Config.IAP_CLIENT_ID,
-                                                     method='POST')
-        else:
-            response = requests.post(process_job_url)
+        response = iap_requests.make_request(method='POST', url=process_job_url)
         response.raise_for_status()
 
         if delete_after_upload:

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -26,10 +26,8 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
                                          data=multipart_data)
     response.raise_for_status()
 
-    # TODO debug
-    print(response.status_code, response.text)
-
-    file_id = response.json()
+    # file_id = response.json()
+    file_id = response.text
 
     request_params = {
         'fileId': file_id,

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -3,6 +3,8 @@ import time
 import uuid
 import requests
 from requests_toolbelt import MultipartEncoder
+
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -16,7 +18,15 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
 
     url = f'{Config.SUPPORT_TOOL_API}/upload'
 
-    response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
+    # response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 content_type=multipart_data.content_type,
+                                                 data=multipart_data)
+    else:
+        response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
     response.raise_for_status()
 
     file_id = response.json()
@@ -29,7 +39,13 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     }
 
     create_job_url = f'{Config.SUPPORT_TOOL_API}/job'
-    response = requests.post(create_job_url, params=request_params)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(create_job_url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 params=request_params)
+    else:
+        response = requests.post(create_job_url, params=request_params)
     response.raise_for_status()
 
     job_id = response.json()
@@ -51,7 +67,13 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
 
     if file_validated:
         process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'
-        response = requests.post(process_job_url)
+
+        if Config.IAP_CLIENT_ID:
+            response = iap_requests.make_iap_request(process_job_url,
+                                                     Config.IAP_CLIENT_ID,
+                                                     method='POST')
+        else:
+            response = requests.post(process_job_url)
         response.raise_for_status()
 
         if delete_after_upload:

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -51,6 +51,9 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
         response = requests.get(get_job_url)
         response.raise_for_status()
 
+        # TODO debug
+        print(response.text)
+        
         if response.json().get("jobStatus") == "VALIDATED_OK":
             file_validated = True
             break

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -18,7 +18,10 @@ def upload_and_process_file_by_api(collex_id, file_path, job_type, delete_after_
 
     wait_for_job_file_validation(job_id)
 
-    process_job(job_id, file_id, delete_after_upload=delete_after_upload)
+    process_job(job_id)
+
+    if delete_after_upload:
+        os.unlink(file_path)
 
 
 def upload_file_by_api(file_path: str, file_name: str) -> str:
@@ -68,10 +71,7 @@ def wait_for_job_file_validation(job_id: str, timeout_sec=30) -> None:
     else: # Executes if the while condition is false, without breaking out of the loop
         test_helper.fail(f"File did not pass validation before timeout, job response: {response.json()}")
 
-def process_job(job_id: str, file_path: str, delete_after_upload: bool) -> None:
+def process_job(job_id: str) -> None:
     process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'
     response = iap_requests.make_request(method='POST', url=process_job_url)
     response.raise_for_status()
-
-    if delete_after_upload:
-        os.unlink(file_path)

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -27,7 +27,7 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     response.raise_for_status()
 
     # file_id = response.json()
-    file_id = response.text
+    file_id = str(response.text.strip('"'))
 
     request_params = {
         'fileId': file_id,

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -1,7 +1,7 @@
 import os
 import time
 import uuid
-import requests
+
 from requests_toolbelt import MultipartEncoder
 
 from acceptance_tests.utilities import iap_requests
@@ -55,6 +55,7 @@ def create_job(collex_id: str, file_name: str, file_id: str, job_type: str) -> s
     job_id = str(response.text.strip('"'))
     return job_id
 
+
 def wait_for_job_file_validation(job_id: str, timeout_sec=30) -> None:
     get_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}'
 
@@ -68,8 +69,9 @@ def wait_for_job_file_validation(job_id: str, timeout_sec=30) -> None:
             break
         else:
             time.sleep(1)
-    else: # Executes if the while condition is false, without breaking out of the loop
+    else:  # Executes if the while condition is false, without breaking out of the loop
         test_helper.fail(f"File did not pass validation before timeout, job response: {response.json()}")
+
 
 def process_job(job_id: str) -> None:
     process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -9,9 +9,19 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=False):
+def upload_and_process_file_by_api(collex_id, file_path, job_type, delete_after_upload=False):
     file_name = f'{job_type}_{str(uuid.uuid4())}.csv'
 
+    file_id = upload_file_by_api(file_path, file_name)
+
+    job_id = create_job(collex_id, file_name, file_id, job_type)
+
+    wait_for_job_file_validation(job_id)
+
+    process_job(job_id, file_id, delete_after_upload=delete_after_upload)
+
+
+def upload_file_by_api(file_path: str, file_name: str) -> str:
     multipart_data = MultipartEncoder(fields={
         'file': (file_name, open(file_path, 'rb'), 'text/plain')
     })
@@ -24,7 +34,10 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
                                          data=multipart_data)
     response.raise_for_status()
     file_id = str(response.text.strip('"'))
+    return file_id
 
+
+def create_job(collex_id: str, file_name: str, file_id: str, job_type: str) -> str:
     request_params = {
         'fileId': file_id,
         'fileName': file_name,
@@ -37,28 +50,28 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     response.raise_for_status()
 
     job_id = str(response.text.strip('"'))
+    return job_id
 
+def wait_for_job_file_validation(job_id: str, timeout_sec=30) -> None:
     get_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}'
 
-    deadline = time.time() + 30
-    file_validated = False
+    deadline = time.time() + timeout_sec
 
     while time.time() < deadline:
         response = iap_requests.make_request('GET', url=get_job_url)
         response.raise_for_status()
 
         if response.json().get("jobStatus") == "VALIDATED_OK":
-            file_validated = True
             break
         else:
             time.sleep(1)
-
-    if file_validated:
-        process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'
-        response = iap_requests.make_request(method='POST', url=process_job_url)
-        response.raise_for_status()
-
-        if delete_after_upload:
-            os.unlink(file_path)
-    else:
+    else: # Executes if the while condition is false, without breaking out of the loop
         test_helper.fail(f"File did not pass validation before timeout, job response: {response.json()}")
+
+def process_job(job_id: str, file_path: str, delete_after_upload: bool) -> None:
+    process_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}/process'
+    response = iap_requests.make_request(method='POST', url=process_job_url)
+    response.raise_for_status()
+
+    if delete_after_upload:
+        os.unlink(file_path)

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -18,15 +18,11 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
 
     url = f'{Config.SUPPORT_TOOL_API}/upload'
 
-    # TODO fix file upload
-    # response = requests.post(url, data=multipart_data, headers={'Content-Type': multipart_data.content_type})
     response = iap_requests.make_request(method='POST',
                                          url=url,
                                          headers={'Content-Type': multipart_data.content_type},
                                          data=multipart_data)
     response.raise_for_status()
-
-    # file_id = response.json()
     file_id = str(response.text.strip('"'))
 
     request_params = {
@@ -48,11 +44,8 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     file_validated = False
 
     while time.time() < deadline:
-        response = requests.get(get_job_url)
+        response = iap_requests.make_request('GET', url=get_job_url)
         response.raise_for_status()
-
-        # TODO debug
-        print(response.text[:200])
 
         if response.json().get("jobStatus") == "VALIDATED_OK":
             file_validated = True

--- a/acceptance_tests/utilities/file_to_process_upload_helper.py
+++ b/acceptance_tests/utilities/file_to_process_upload_helper.py
@@ -40,7 +40,7 @@ def upload_file_via_api(collex_id, file_path, job_type, delete_after_upload=Fals
     response = iap_requests.make_request(method='POST', url=create_job_url, params=request_params)
     response.raise_for_status()
 
-    job_id = response.json()
+    job_id = str(response.text.strip('"'))
 
     get_job_url = f'{Config.SUPPORT_TOOL_API}/job/{job_id}'
 

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -17,11 +17,11 @@ def make_request(method: str = "GET", url: str = None, **kwargs) -> requests.Res
     """
     #TODO Remove debug
     if Config.IAP_CLIENT_ID:
-        reponse = _make_iap_request(method, url, **kwargs)
+        response = _make_iap_request(method, url, **kwargs)
     else:
         response = requests.request(method, url, **kwargs)
-    print(response.text, reponse.status_code, reponse.headers)
-    return reponse
+    print(response.text, response.status_code, response.headers)
+    return response
 
 def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> requests.Response:
     """Makes a request to an application protected by Identity-Aware Proxy.

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -15,13 +15,10 @@ def make_request(method: str = "GET", url: str = None, **kwargs) -> requests.Res
       **kwargs: Any of the parameters defined for the request function:
                 https://github.com/requests/requests/blob/master/requests/api.py
     """
-    #TODO Remove debug
     if Config.IAP_CLIENT_ID:
-        response = _make_iap_request(method, url, **kwargs)
-    else:
-        response = requests.request(method, url, **kwargs)
-    print(response.text, response.status_code, response.headers)
-    return response
+        return _make_iap_request(method, url, **kwargs)
+    return requests.request(method, url, **kwargs)
+
 
 def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> requests.Response:
     """Makes a request to an application protected by Identity-Aware Proxy.

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -1,0 +1,42 @@
+import requests
+from google.auth.transport.requests import Request
+from google.oauth2 import id_token
+from requests import Response
+
+
+def make_iap_request(url: str, client_id: str, method: str = 'GET', content_type=None, **kwargs) -> Response:
+    """Makes a request to an application protected by Identity-Aware Proxy.
+    Args:
+      url: The Identity-Aware Proxy-protected URL to fetch.
+      client_id: The client ID used by Identity-Aware Proxy.
+      method: The request method to use
+              ('GET', 'OPTIONS', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE')
+      content_type: Sets content type when uploading files.
+      **kwargs: Any of the parameters defined for the request function:
+                https://github.com/requests/requests/blob/master/requests/api.py
+                If no timeout is provided, it is set to 90 by default.
+    Returns:
+      The requests Response object return by the requests call
+    """
+
+    # Set the default timeout, if missing
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = 90
+
+    # Obtain an OpenID Connect (OIDC) token from metadata server or using service
+    # account.
+    open_id_connect_token = id_token.fetch_id_token(Request(), client_id)
+
+    if content_type:
+        headers = {'Authorization': 'Bearer {}'.format(open_id_connect_token),
+                   'Content-Type': content_type}
+    else:
+        headers = {'Authorization': 'Bearer {}'.format(open_id_connect_token)}
+
+    # Fetch the Identity-Aware Proxy-protected URL, including an
+    # Authorization header containing "Bearer " followed by a
+    # Google-issued OpenID Connect token for the service account.
+    response = requests.request(
+        method, url,
+        headers=headers, **kwargs)
+    return response

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -46,7 +46,7 @@ def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> request
 
     # Set an authorization header containing "Bearer " followed by a
     # Google-issued OpenID Connect token for the service account.
-    kwargs['headers']['Authorization'] = f'Bearer {open_id_connect_token}'
+    kwargs['headers']['Proxy-Authorization'] = f'Bearer {open_id_connect_token}'
 
     return requests.request(
         method, url, **kwargs)

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -5,22 +5,24 @@ from google.oauth2 import id_token
 from config import Config
 
 
-def make_request(method: str = "GET", url: str = None, **kwargs) -> requests.Response:
-    """Make an IAP authorized request if IAP config is present,
-    otherwise fall back on a regular, unauthenticated request
+def make_request(method: str = "GET", url: str = None,
+                 iap_client_id: str = Config.SUPPORT_TOOL_IAP_CLIENT_ID, **kwargs) -> requests.Response:
+    """Make an IAP authorized request if IAP config is present
     Kwargs:
       method: The request method to use
               ('GET', 'OPTIONS', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE')
       url: The Identity-Aware Proxy-protected URL to fetch.
+      iap_client_id: (Optional) The IAP Client ID to use for authentication. If not configured, it will fall back on
+                     a regular, unauthenticated request. Defaults to the configured Support Tool Client if present.
       **kwargs: Any of the parameters defined for the request function:
                 https://github.com/requests/requests/blob/master/requests/api.py
     """
-    if Config.SUPPORT_TOOL_IAP_CLIENT_ID:
+    if iap_client_id:
         return _make_iap_request(method, url, **kwargs)
     return requests.request(method, url, **kwargs)
 
 
-def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> requests.Response:
+def _make_iap_request(method: str = 'GET', url: str = None, iap_client_id: str = None, **kwargs) -> requests.Response:
     """Makes a request to an application protected by Identity-Aware Proxy.
     Args:
       method: The request method to use
@@ -38,7 +40,7 @@ def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> request
         kwargs['timeout'] = 90
 
     # Obtain an OpenID Connect (OIDC) token from metadata server or using service account.
-    open_id_connect_token = id_token.fetch_id_token(Request(), Config.SUPPORT_TOOL_IAP_CLIENT_ID)
+    open_id_connect_token = id_token.fetch_id_token(Request(), iap_client_id)
 
     # Initialise headers if none are passed in the kwargs
     if 'headers' not in kwargs:
@@ -48,5 +50,4 @@ def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> request
     # Google-issued OpenID Connect token for the service account.
     kwargs['headers']['Proxy-Authorization'] = f'Bearer {open_id_connect_token}'
 
-    return requests.request(
-        method, url, **kwargs)
+    return requests.request(method, url, **kwargs)

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -18,7 +18,7 @@ def make_request(method: str = "GET", url: str = None,
                 https://github.com/requests/requests/blob/master/requests/api.py
     """
     if iap_client_id:
-        return _make_iap_request(method, url, **kwargs)
+        return _make_iap_request(method, url, iap_client_id, **kwargs)
     return requests.request(method, url, **kwargs)
 
 

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -15,10 +15,13 @@ def make_request(method: str = "GET", url: str = None, **kwargs) -> requests.Res
       **kwargs: Any of the parameters defined for the request function:
                 https://github.com/requests/requests/blob/master/requests/api.py
     """
+    #TODO Remove debug
     if Config.IAP_CLIENT_ID:
-        return _make_iap_request(method, url, **kwargs)
-    return requests.request(method, url, **kwargs)
-
+        reponse = _make_iap_request(method, url, **kwargs)
+    else:
+        response = requests.request(method, url, **kwargs)
+    print(response.text, reponse.status_code, reponse.headers)
+    return reponse
 
 def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> requests.Response:
     """Makes a request to an application protected by Identity-Aware Proxy.

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -15,7 +15,7 @@ def make_request(method: str = "GET", url: str = None, **kwargs) -> requests.Res
       **kwargs: Any of the parameters defined for the request function:
                 https://github.com/requests/requests/blob/master/requests/api.py
     """
-    if Config.IAP_CLIENT_ID:
+    if Config.SUPPORT_TOOL_IAP_CLIENT_ID:
         return _make_iap_request(method, url, **kwargs)
     return requests.request(method, url, **kwargs)
 
@@ -38,7 +38,7 @@ def _make_iap_request(method: str = 'GET', url: str = None, **kwargs) -> request
         kwargs['timeout'] = 90
 
     # Obtain an OpenID Connect (OIDC) token from metadata server or using service account.
-    open_id_connect_token = id_token.fetch_id_token(Request(), Config.IAP_CLIENT_ID)
+    open_id_connect_token = id_token.fetch_id_token(Request(), Config.SUPPORT_TOOL_IAP_CLIENT_ID)
 
     # Initialise headers if none are passed in the kwargs
     if 'headers' not in kwargs:

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -2,8 +2,6 @@ from datetime import datetime
 from functools import partial
 from typing import Mapping
 
-import requests
-
 from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.pubsub_helper import get_matching_pubsub_message_acking_others
 from acceptance_tests.utilities.test_case_helper import test_helper

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -4,6 +4,7 @@ from typing import Mapping
 
 import requests
 
+from acceptance_tests.utilities import iap_requests
 from acceptance_tests.utilities.pubsub_helper import get_matching_pubsub_message_acking_others
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -22,7 +23,14 @@ def add_survey(sample_validation_rules, test_start_time, sample_definition_url="
             "sampleDefinitionUrl": sample_definition_url,
             "metadata": {'foo': 'bar'}}
 
-    response = requests.post(url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(url, json=body)
+
     response.raise_for_status()
 
     survey_id = response.json()

--- a/acceptance_tests/utilities/survey_helper.py
+++ b/acceptance_tests/utilities/survey_helper.py
@@ -23,14 +23,7 @@ def add_survey(sample_validation_rules, test_start_time, sample_definition_url="
             "sampleDefinitionUrl": sample_definition_url,
             "metadata": {'foo': 'bar'}}
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(url, json=body)
-
+    response = iap_requests.make_request(method='POST', url=url, json=body)
     response.raise_for_status()
 
     survey_id = response.json()

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -4,6 +4,7 @@ import uuid
 
 import requests
 
+from acceptance_tests.utilities import iap_requests
 from config import Config
 
 
@@ -21,7 +22,13 @@ def create_template(create_url, pack_code, template, notify_template_id=None, ex
     if export_file_destination:
         body['exportFileDestination'] = export_file_destination
 
-    response = requests.post(create_url, json=body)
+    if Config.IAP_CLIENT_ID:
+        response = iap_requests.make_iap_request(create_url,
+                                                 Config.IAP_CLIENT_ID,
+                                                 method='POST',
+                                                 json=body)
+    else:
+        response = requests.post(create_url, json=body)
     response.raise_for_status()
 
 

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -22,13 +22,7 @@ def create_template(create_url, pack_code, template, notify_template_id=None, ex
     if export_file_destination:
         body['exportFileDestination'] = export_file_destination
 
-    if Config.IAP_CLIENT_ID:
-        response = iap_requests.make_iap_request(create_url,
-                                                 Config.IAP_CLIENT_ID,
-                                                 method='POST',
-                                                 json=body)
-    else:
-        response = requests.post(create_url, json=body)
+    response = iap_requests.make_request(method='POST', url=create_url, json=body)
     response.raise_for_status()
 
 

--- a/acceptance_tests/utilities/template_helper.py
+++ b/acceptance_tests/utilities/template_helper.py
@@ -2,8 +2,6 @@ import random
 import string
 import uuid
 
-import requests
-
 from acceptance_tests.utilities import iap_requests
 from config import Config
 

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -22,7 +22,7 @@ spec:
               cp /home/acceptancetests/postgresql/* /home/acceptancetests/.postgresql
               chmod 0600 /home/acceptancetests/.postgresql/postgresql.key
               # the above is a workaround to get round the permissions as currently we cant mount it without doing this
-    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:$MANIFEST_IMAGE_TAG
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:72-spike-ats-should-go-via-https-domain-and-use-iap
     tty: true
     stdin: true
     imagePullPolicy: Always
@@ -81,7 +81,7 @@ spec:
     - name: SUPPLIER_CONFIG_JSON_PATH
       value: "/home/acceptancetests/destination_config/export-file-destination-config.json"
     - name: SUPPORT_TOOL_HOST
-      value: "support-tool"
+      value: "<your-support-tool>.rm.gcp.onsdigital.uk"
     - name: SUPPORT_TOOL_PORT
       value: "80"
     - name: EXCEPTIONMANAGER_CONNECTION_HOST
@@ -115,6 +115,11 @@ spec:
       value: "BUCKET"
     - name: EQ_FLUSH_STUB_URL
       value: "http://eq-stub"
+    - name: IAP_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: support-tool-iap
+          key: client_id
   volumes:
   - name: export-file-destinations
     secret:

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -22,7 +22,7 @@ spec:
               cp /home/acceptancetests/postgresql/* /home/acceptancetests/.postgresql
               chmod 0600 /home/acceptancetests/.postgresql/postgresql.key
               # the above is a workaround to get round the permissions as currently we cant mount it without doing this
-    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:72-spike-ats-should-go-via-https-domain-and-use-iap
+    image: europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-acceptance-tests:$MANIFEST_IMAGE_TAG
     tty: true
     stdin: true
     imagePullPolicy: Always
@@ -81,9 +81,13 @@ spec:
     - name: SUPPLIER_CONFIG_JSON_PATH
       value: "/home/acceptancetests/destination_config/export-file-destination-config.json"
     - name: SUPPORT_TOOL_HOST
-      value: "<your-support-tool>.rm.gcp.onsdigital.uk"
+      value: "support-tool-$ENV.rm.gcp.onsdigital.uk"
     - name: SUPPORT_TOOL_PORT
       value: "80"
+    - name: SUPPORT_TOOL_PROTOCOL
+      value: "https"
+    - name: SUPPORT_TOOL_UI_URL
+      value: "http://support-tool"
     - name: EXCEPTIONMANAGER_CONNECTION_HOST
       value: "exception-manager"
     - name: EXCEPTIONMANAGER_CONNECTION_PORT
@@ -115,7 +119,7 @@ spec:
       value: "BUCKET"
     - name: EQ_FLUSH_STUB_URL
       value: "http://eq-stub"
-    - name: IAP_CLIENT_ID
+    - name: SUPPORT_TOOL_IAP_CLIENT_ID
       valueFrom:
         secretKeyRef:
           name: support-tool-iap

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -124,7 +124,7 @@ spec:
         secretKeyRef:
           name: support-tool-iap
           key: client_id
-    - name: ORIGINATING_USER
+    - name: API_USER_EMAIL
       value: "acceptance-tests@ssdc-rm-$ENV.iam.gserviceaccount.com"
   volumes:
   - name: export-file-destinations

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -124,6 +124,8 @@ spec:
         secretKeyRef:
           name: support-tool-iap
           key: client_id
+    - name: ORIGINATING_USER
+      value: "acceptance-tests@ssdc-rm-$ENV.iam.gserviceaccount.com"
   volumes:
   - name: export-file-destinations
     secret:

--- a/config.py
+++ b/config.py
@@ -47,10 +47,25 @@ class Config:
     EXCEPTIONMANAGER_CONNECTION_PORT = os.getenv('EXCEPTIONMANAGER_CONNECTION_PORT', '8666')
     EXCEPTION_MANAGER_URL = f'http://{EXCEPTIONMANAGER_CONNECTION_HOST}:{EXCEPTIONMANAGER_CONNECTION_PORT}'
 
+    # Providing an IAP client ID will switch the tests to attempt to make all support tool requests with IAP auth,
+    # This uses the default auth available in the environment
+    SUPPORT_TOOL_IAP_CLIENT_ID = os.getenv('SUPPORT_TOOL_IAP_CLIENT_ID')
+
     SUPPORT_TOOL_HOST = os.getenv('SUPPORT_TOOL_HOST', 'localhost')
     SUPPORT_TOOL_PORT = os.getenv('SUPPORT_TOOL_PORT', '9999')
-    SUPPORT_TOOL_API = f'https://{SUPPORT_TOOL_HOST}/api'
-    SUPPORT_TOOL_URL = f'https://{SUPPORT_TOOL_HOST}'
+
+    # To go via IAP this must be set to 'https'
+    SUPPORT_TOOL_PROTOCOL = os.getenv('SUPPORT_TOOL_PROTOCOL', 'http')
+
+    if SUPPORT_TOOL_PORT == '80':
+        SUPPORT_TOOL_API = f'{SUPPORT_TOOL_PROTOCOL}://{SUPPORT_TOOL_HOST}/api'
+        SUPPORT_TOOL_URL = f'{SUPPORT_TOOL_PROTOCOL}://{SUPPORT_TOOL_HOST}'
+    else:
+        SUPPORT_TOOL_API = f'{SUPPORT_TOOL_PROTOCOL}://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}/api'
+        SUPPORT_TOOL_URL = f'{SUPPORT_TOOL_PROTOCOL}://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}'
+
+    # Allow the URL used for UI navigation to be set differently, since the browser driver cannot support IAP auth
+    SUPPORT_TOOL_UI_URL = os.getenv('SUPPORT_TOOL_UI_URL', SUPPORT_TOOL_URL)
 
     NOTIFY_SERVICE_HOST = os.getenv('NOTIFY_SERVICE_HOST', 'localhost')
     NOTIFY_SERVICE_PORT = os.getenv('NOTIFY_SERVICE_PORT', '8162')
@@ -105,5 +120,3 @@ class Config:
 
     SUPPLIER_INTERNAL_REPROGRAPHICS = os.getenv('SUPPLIER_INTERNAL_REPROGRAPHICS', 'internal_reprographics')
     SUPPLIER_DEFAULT_TEST = os.getenv('SUPPLIER_DEFAULT_TEST', 'test_supplier')
-
-    IAP_CLIENT_ID = os.getenv('IAP_CLIENT_ID')

--- a/config.py
+++ b/config.py
@@ -49,8 +49,8 @@ class Config:
 
     SUPPORT_TOOL_HOST = os.getenv('SUPPORT_TOOL_HOST', 'localhost')
     SUPPORT_TOOL_PORT = os.getenv('SUPPORT_TOOL_PORT', '9999')
-    SUPPORT_TOOL_API = f'http://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}/api'
-    SUPPORT_TOOL_URL = f'http://{SUPPORT_TOOL_HOST}:{SUPPORT_TOOL_PORT}'
+    SUPPORT_TOOL_API = f'https://{SUPPORT_TOOL_HOST}/api'
+    SUPPORT_TOOL_URL = f'https://{SUPPORT_TOOL_HOST}'
 
     NOTIFY_SERVICE_HOST = os.getenv('NOTIFY_SERVICE_HOST', 'localhost')
     NOTIFY_SERVICE_PORT = os.getenv('NOTIFY_SERVICE_PORT', '8162')
@@ -105,3 +105,5 @@ class Config:
 
     SUPPLIER_INTERNAL_REPROGRAPHICS = os.getenv('SUPPLIER_INTERNAL_REPROGRAPHICS', 'internal_reprographics')
     SUPPLIER_DEFAULT_TEST = os.getenv('SUPPLIER_DEFAULT_TEST', 'test_supplier')
+
+    IAP_CLIENT_ID = os.getenv('IAP_CLIENT_ID')

--- a/config.py
+++ b/config.py
@@ -107,7 +107,8 @@ class Config:
     EQ_DECRYPTION_KEY = jwk.JWK.from_pem(JWT_DICT['jwePrivateKey']['value'].encode())
     EQ_VERIFICATION_KEY = jwk.JWK.from_pem(JWT_DICT['jwsPublicKey']['value'].encode())
 
-    SAMPLE_LOAD_ORIGINATING_USER = os.getenv('ORIGINATING_USER', 'dummy@fake-email.com')
+    API_USER_EMAIL = os.getenv('API_USER_EMAIL', 'dummy@fake-email.com')
+    UI_USER_EMAIL = os.getenv('UI_USER_EMAIL', 'dummy@fake-email.com')
 
     CODE_GUIDE_MARKDOWN_FILE_PATH = Path(
         os.getenv('CODE_GUIDE_MARKDOWN_FILE_PATH') or Path(__file__).parent.joinpath('CODE_GUIDE.md'))

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -32,11 +32,12 @@ echo "Running with behave tags: \"$BEHAVE_TAGS\""
 IMAGE_TAG="${1:-latest}"
 COMPLETE_MANIFEST="tmp_${IMAGE_TAG}_acceptance_tests_pod.yml"
 
-echo "Using image tag [$IMAGE_TAG], saving manifest as \"$COMPLETE_MANIFEST\""
+echo "Using image tag [$IMAGE_TAG] and env [$ENV], saving manifest as \"$COMPLETE_MANIFEST\""
 
 # Replace "$MANIFEST_IMAGE_TAG" in the target manifest with the value of IMAGE_TAG,
+# And replace the "$ENV" with the value of ENV for environment specific values
 # save the output to the tmp_manifests directory
-sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" acceptance_tests_pod.yml > $COMPLETE_MANIFEST
+sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" -e "s/\$ENV/$ENV/" acceptance_tests_pod.yml > $COMPLETE_MANIFEST
 
 
 kubectl delete pod acceptance-tests --wait || true

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -8,11 +8,12 @@ image_resource:
 params:
   # Required
   SERVICE_ACCOUNT_JSON: # GCP service account key JSON
-  GCP_PROJECT_NAME: # Target project which hosts the K8s cluster
-  KUBERNETES_CLUSTER: # Target K8s cluster ID
+  GCP_PROJECT_NAME:     # Target project which hosts the K8s cluster
+  KUBERNETES_CLUSTER:   # Target K8s cluster ID
+  ENV:                  # Environment suffix for the project, assuming the project follows our ssdc-rm-<ENV> convention
 
   # Optional
-  IMAGE_TAG: # Optional, specific acceptance tests image tag. If not set, will default to using the given commit ref from the "acceptance-tests-repo"
+  IMAGE_TAG:   # Optional, specific acceptance tests image tag. If not set, will default to using the given commit ref from the "acceptance-tests-repo"
   BEHAVE_TAGS: # Optional, list of behave tags passed into the behave feature run
 
 inputs:
@@ -38,7 +39,7 @@ run:
       
       # Substitute the image tag into the template manifest yaml
       COMPLETE_MANIFEST="${IMAGE_TAG}_acceptance_tests_pod.yml"
-      sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" acceptance-tests-repo/acceptance_tests_pod.yml > $COMPLETE_MANIFEST
+      sed -e "s/\$MANIFEST_IMAGE_TAG/$IMAGE_TAG/" -e "s/\$ENV/$ENV/" acceptance-tests-repo/acceptance_tests_pod.yml > $COMPLETE_MANIFEST
 
       # Pre-clean up any left over acceptance test pod
       kubectl delete pod acceptance-tests --wait || true


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Following on from the initial spike #198, we want to switch to sending API requests via the full IAP route when testing in the cloud. 

This has a caveat, the UI tests currently can't use IAP so still must go through the private network endpoint instead, but all direct support tool API calls can now go via IAP in a cloud environment.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add a utility to authenticate requests with IAP tokens if an IAP client is specified
- Add separate support tool and user config for UI tests
- Add config to the pod manifest and kubectl task

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Tested in a cloud dev environment.
If you want to run it in your own environment, you'll need to run the new DDL script to create the support tool service account user for the acceptance tests and use the linked terraform branch to add the correct permission.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-360