### PR TITLE
SDCSRM-441-update-dummy-notify-config

### DIFF
--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -53,5 +53,5 @@ Feature: Test basic Support Tool Functionality
     @regression
     Examples:
       | notify service ref                           |
-      | Office_for_National_Statistics_surveys_UKHSA |
+      | Office_for_National_Statistics_surveys_NHS |
       | test_service                                 |


### PR DESCRIPTION
# Motivation and Context
With the new notify Ref, the ATs would fail since it still had the old notify ref from wcis hardcoded
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Changed the notify service ref to `Office_for_National_Statistics_surveys_NHS`

# How to test?
Run the ATs with all the other branches on the jira card and check that is passes.

# Links
[DDL PR](https://github.com/ONSdigital/ssdc-rm-ddl/pull/200)
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-441)

# Screenshots (if appropriate):