### PR TITLE
SDCSRM-520 Update UI tests to check actionRuleStatus

### DIFF
--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -161,18 +161,18 @@ def click_action_rule_button(context):
 
 
 @step('I can see the Action Rule has been triggered and export files have been created')
-def check_for_action_rule_triggered(context):
-    poll_action_rule_trigger(context.browser, context.pack_code)
+def check_for_action_rule_completed(context):
+    poll_action_rule_completed(context.browser, context.pack_code)
     context.emitted_uacs = get_number_of_uac_update_events(context.sample_count, context.test_start_utc_datetime)
     check_export_file(context)
 
 
 @retry(wait=wait_fixed(2), stop=stop_after_delay(120))
-def poll_action_rule_trigger(browser, pack_code):
+def poll_action_rule_completed(browser, pack_code):
     browser.reload()
     test_helper.assertEquals(
         len(browser.find_by_id('actionRuleTable').first.find_by_text(pack_code)), 1)
-    test_helper.assertEquals(browser.find_by_id('hasTriggered').text, 'YES')
+    test_helper.assertEquals(browser.find_by_id('actionRuleStatus').text, 'COMPLETED')
 
 
 @step('the Create Email Template button is clicked on')
@@ -227,5 +227,5 @@ def click_email_action_rule_button(context, email_column):
 
 @step('I can see the Action Rule has been triggered and emails sent to notify api with email column "{email_column}"')
 def check_action_rule_triggered_for_email(context, email_column):
-    poll_action_rule_trigger(context.browser, context.pack_code)
+    poll_action_rule_completed(context.browser, context.pack_code)
     check_notify_called_with_correct_emails_and_uacs(context, email_column)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
With adding an action rule status, we are removing the "has triggered" field from the support tool UI, so the tests that check it need to be updated to check the status instead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Change action has triggered checks in the support tool to use the new status instead

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build the DDL, case processor and support tool changes linked to this ticket locally, then run Docker Dev
Run the tests on this branch.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-520