### PR TITLE
SDCSRM-542 Dependabot Security Only PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,13 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+    target-branch: main
+    groups:
+      pip-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
-    labels:
-      - "patch"
-      - "dependencies"
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
           - "*"
     schedule:
       interval: daily
+    labels:
+      - "patch"
+      - "dependencies"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -76,11 +76,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
-                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516",
+                "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2024.2.2"
+            "version": "==2024.6.2"
         },
         "cffi": {
             "hashes": [
@@ -699,12 +699,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5",
-                "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"
+                "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+                "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==2.32.0"
+            "version": "==2.32.3"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -813,7 +813,6 @@
                 "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
                 "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==2.2.2"
         },


### PR DESCRIPTION
# Motivation and Context
We want to limit the amount of dependabot PRs

# What has changed
Enabled grouping and only allowed security PRs
Updated dependency requests due to vulnerability warning

# How to test?
Check it looks ok

# Links
[SDCSRM-542](https://jira.ons.gov.uk/browse/SDCSRM-542)