### PR TITLE
Sdcsrm 619 fix action rule datetime display

### DIFF
--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -75,4 +75,4 @@ Feature: Test basic Support Tool Functionality
     Examples:
       | notify service ref                         | action rule date | expected timezone |
       | Office_for_National_Statistics_surveys_NHS | 01-01-2124       | GMT               |
-      | test_service                               | 06-06-2124       | GMT+01:00         |
+      | test_service                               | 06-06-2124       | BST               |

--- a/acceptance_tests/features/SupportTool_UI.feature
+++ b/acceptance_tests/features/SupportTool_UI.feature
@@ -52,6 +52,27 @@ Feature: Test basic Support Tool Functionality
 
     @regression
     Examples:
-      | notify service ref                           |
+      | notify service ref                         |
       | Office_for_National_Statistics_surveys_NHS |
-      | test_service                                 |
+      | test_service                               |
+
+  @reset_notify_stub
+  Scenario Outline: Create an Email Action Rule in the future
+    Given the support tool landing page is displayed
+    And the Create Email Template button is clicked on
+    And an email template with packcode "email-packcode", notify service ref "<notify service ref>" and template ["__uac__"] has been created
+    And I should see the email template in the template list
+    And the Create Survey Button is clicked on
+    And a Survey called "EmailTest" plus unique suffix is created for sample file "sis_survey_link.csv" with sensitive columns ["emailAddress"]
+    And the survey is clicked on it should display the collection exercise page
+    And the create collection exercise button is clicked, the details are submitted and the exercise is created
+    And the email template has been added to the allow on action rule list
+    And the collection exercise is clicked on, navigating to the selected exercise details page
+    When I create an email action rule on the date "<action rule date>" with email column "emailAddress"
+    Then I can see the action rule has been created in "<expected timezone>"
+
+    @regression
+    Examples:
+      | notify service ref                         | action rule date | expected timezone |
+      | Office_for_National_Statistics_surveys_NHS | 01-01-2124       | GMT               |
+      | test_service                               | 06-06-2124       | GMT+01:00         |

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -245,4 +245,11 @@ def check_action_rule_triggered_for_email(context, email_column):
 @step('I can see the action rule has been created in "{expected_timezone}"')
 def check_action_rule_triggered_for_email_in_future(context, expected_timezone):
     action_rule_date_time_str = context.browser.find_by_id('actionRuleDateTime', wait_time=30).text
-    test_helper.assertEquals(action_rule_date_time_str[21:], expected_timezone)
+
+    if expected_timezone == "GMT":
+        action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z")
+        test_helper.assertIsNone(action_rule_date_time.utcoffset()) # Time is in UTC, so we assert there's no offset
+    else:
+        action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z%z")
+        test_helper.assertEquals(action_rule_date_time.utcoffset().seconds, 3600)
+

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from typing import List
 
 from behave import step
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 from tenacity import retry, stop_after_delay, wait_fixed
 
 from acceptance_tests.features.steps.email_action_rule import check_notify_called_with_correct_emails_and_uacs
@@ -17,9 +20,6 @@ from acceptance_tests.utilities.survey_helper import get_emitted_survey_update
 from acceptance_tests.utilities.test_case_helper import test_helper
 from acceptance_tests.utilities.validation_rule_helper import get_sample_rows_and_generate_open_validation_rules
 from config import Config
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 
 @step("the support tool landing page is displayed")
@@ -215,6 +215,18 @@ def allow_email_template_on_action_rule(context):
 
 @step('I create an email action rule with email column "{email_column}"')
 def click_email_action_rule_button(context, email_column):
+    setup_email_action_rule(context, email_column)
+    context.browser.find_by_id('createActionRuleBtn').click()
+
+
+@step('I create an email action rule on the date "{action_rule_date}" with email column "{email_column}"')
+def click_email_action_rule_button_with_date(context, action_rule_date, email_column):
+    setup_email_action_rule(context, email_column)
+    context.browser.find_by_id("triggerDate")[0].value = action_rule_date
+    context.browser.find_by_id('createActionRuleBtn').click()
+
+
+def setup_email_action_rule(context, email_column):
     context.browser.find_by_id('createActionRuleDialogBtn').click()
     context.browser.find_by_id('selectActionRuleType').click()
     context.browser.find_by_value('Email').click()
@@ -222,10 +234,15 @@ def click_email_action_rule_button(context, email_column):
     context.browser.find_by_id(context.pack_code, wait_time=30).click()
     context.browser.find_by_id('selectActionRuleEmailColumn').click()
     context.browser.find_by_id(email_column, wait_time=30).click()
-    context.browser.find_by_id('createActionRuleBtn').click()
 
 
 @step('I can see the Action Rule has been triggered and emails sent to notify api with email column "{email_column}"')
 def check_action_rule_triggered_for_email(context, email_column):
     poll_action_rule_completed(context.browser, context.pack_code)
     check_notify_called_with_correct_emails_and_uacs(context, email_column)
+
+
+@step('I can see the action rule has been created in "{expected_timezone}"')
+def check_action_rule_triggered_for_email_in_future(context, expected_timezone):
+    action_rule_date_time_str = context.browser.find_by_id('actionRuleDateTime', wait_time=30).text
+    test_helper.assertEquals(action_rule_date_time_str[21:], expected_timezone)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](/CODE_GUIDE.md#context-index) has been kept up to date
We've had some issues in prod around the datetimes that action rules are created in. There's a PR in the [support tool](https://github.com/ONSdigital/ssdc-rm-support-tool/pull/352) to update the datetimes to show them in the timezone they were created in
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added test to create an action rule in the future to see if it matches the expected timezone
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with the support tool branch and make sure all tests pass
- Run the tests in GCP as well to make sure the behaviour is the same
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-619)
# Screenshots (if appropriate):