### PR TITLE
Added docker login step to Megalinter github action

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
+      # Authenticating with Dockerhub ensures image pulls are authenticated, so not as severely rate limited
+      - name: Log in to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # MegaLinter
       - name: MegaLinter
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# Motivation and Context
Our Megalinter GitHub action is currently not using our docker credentials, causing us to hit their rate limiting and fail jobs

# What has changed
Added login step to megaliter GitHub action