### PR TITLE
Added retry and waits for rh-ui tests to allow UI to fully load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.11-slim
 
 # install google chrome, chromedriver and add acceptancetest user
+# Hardcoding chrome version until the latest stable version is updated
 RUN apt-get -y update && apt-get install -y curl git wget gnupg jq && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &&  \
-    LATEST_COMPATIBLE_CHROME_VERSION=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json | jq -r '.channels."Stable"."version"') && \
+    LATEST_COMPATIBLE_CHROME_VERSION=136.0.7103.113 && \
     wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb && \
     dpkg -i google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb || apt -y -f install && \
     rm google-chrome-stable_${LATEST_COMPATIBLE_CHROME_VERSION}-1_amd64.deb && \

--- a/acceptance_tests/features/steps/rh_ui.py
+++ b/acceptance_tests/features/steps/rh_ui.py
@@ -2,6 +2,7 @@ import json
 from urllib.parse import urlparse, parse_qs
 
 from behave import step
+from tenacity import wait_fixed, retry, stop_after_delay
 
 from acceptance_tests.features.steps.events_emitted import check_uac_update_msgs_emitted_with_qid_active
 from acceptance_tests.features.steps.notify_api import get_uac_from_sms_fulfilment
@@ -80,6 +81,7 @@ def input_receipted_uac(context):
 
 
 @step("they are redirected to the receipted page")
+@retry(wait=wait_fixed(2), stop=stop_after_delay(30))
 def redirected_to_receipted_page(context):
     test_helper.assertIn('This access code has already been used', context.browser.find_by_css('h1').text)
 
@@ -90,6 +92,7 @@ def enter_inactive_uac(context):
 
 
 @step("they are redirected to the inactive uac page")
+@retry(wait=wait_fixed(2), stop=stop_after_delay(30))
 def check_on_inactive_uac_page(context):
     test_helper.assertIn('This questionnaire has now closed', context.browser.find_by_css('h1').text)
 
@@ -122,6 +125,7 @@ def error_section_displayed_with_header_text(context, error_section_header, href
     test_helper.assertEqual(error_text, expected_text)
 
 
+@retry(wait=wait_fixed(2), stop=stop_after_delay(30))
 def _redirect_to_eq(context, language_code):
     expected_url_start = 'session?token='
     test_helper.assertIn(expected_url_start, context.browser.url)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

Some tests are failing in GCP around trying to find text in a url and stale elements in the RH UI. To help this, I've added some retrys to the commands to wait a couple seconds for the page and then do the checks. Seems to be working for me locally now.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added retry decorators to some rh-ui steps to hopefully fix the issue
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run the tests locally and all should pass.
- Run the tests in GCP and all should pass
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-1008)
