### PR TITLE
added support frontend survey unhappy features

### DIFF
--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -20,7 +20,10 @@ Feature: Test functionality of the Support Frontend
     Given the support frontend is displayed
     When the "Create new survey" button is clicked
     And a survey with no filed entered is attempted to be created
-    Then I should see error messages
+    Then I should see 3 problems with this page
+    And I see a "Enter a survey name" error
+    And I see a "Enter a sample definition URL" error
+    And I see a "Select a sample template" error
 
   @regression
   Scenario: Edit a surveys details and removing fields
@@ -29,7 +32,9 @@ Feature: Test functionality of the Support Frontend
     And a survey called "SupportFrontendTest" plus unique suffix is created
     When the name edit link is clicked
     And fields are emptied
-    Then I should see error messages other than for sample template
+    Then I should see 2 problems with this page
+    And I see a "Enter a survey name" error
+    And I see a "Enter a sample definition URL" error
 
   @regression
   Scenario: Create a survey with a too long name

--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -1,13 +1,13 @@
 @UI @SupportFrontend
 Feature: Test functionality of the Support Frontend
 
-  @regression
   Scenario: Create a Survey and View Details
     Given the support frontend is displayed
     When the "Create new survey" button is clicked
     And a survey called "SupportFrontendTest" plus unique suffix is created
     Then I should see the new surveys details
 
+  @regression
   Scenario: Edit a surveys details
     Given the support frontend is displayed
     And the "Create new survey" button is clicked
@@ -15,3 +15,25 @@ Feature: Test functionality of the Support Frontend
     When the name edit link is clicked
     And the name is changed to "EditedSupportFrontendTest"
     Then I should see the edited survey name
+
+  Scenario: Create an invalid survey
+    Given the support frontend is displayed
+    When the "Create new survey" button is clicked
+    And a survey with no filed entered is attempted to be created
+    Then I should see error messages
+
+  @regression
+  Scenario: Edit a surveys details and removing fields
+    Given the support frontend is displayed
+    And the "Create new survey" button is clicked
+    And a survey called "SupportFrontendTest" plus unique suffix is created
+    When the name edit link is clicked
+    And fields are emptied
+    Then I should see error messages other than for sample template
+
+  @regression
+  Scenario: Create a survey with a too long name
+    Given the support frontend is displayed
+    When the "Create new survey" button is clicked
+    And a survey with a name longer than 255 characters is attempted to be created
+    Then the name should be truncated to 255 characters

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -70,6 +70,7 @@ def before_scenario(context, scenario):
         service = Service()
         options = Options()
         options.add_argument("--verbose")
+        options.add_argument("--window-size=1920,1080")
         context.browser = Browser('chrome', headless=Config.HEADLESS, service=service, options=options)
 
 

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -63,15 +63,15 @@ def create_survey_with_no_name(context):
     context.browser.find_by_id("create-survey-button").click()
 
 
-@step('I should see error messages')
-def see_error_messages(context):
+@step('I should see {num_errors} problems with this page')
+def see_number_of_problems(context, num_errors):
     test_helper.assertEqual(context.browser.find_by_id("alert", wait_time=5).first.text,
-                            "There are 3 problems with this page", "No error summary shown")
-    test_helper.assertTrue(context.browser.is_text_present("Enter a survey name"), "No error message shown for name")
-    test_helper.assertTrue(context.browser.is_text_present("Enter a sample definition URL"),
-                           "No error message shown for sample definition URL")
-    test_helper.assertTrue(context.browser.is_text_present("Select a sample template"),
-                           "No error message shown for sample template")
+                            f"There are {num_errors} problems with this page", "No error summary shown")
+
+
+@step('I see a "{text}" error')
+def see_a_text_error(context, text):
+    test_helper.assertTrue(context.browser.is_text_present(text), f"No error {text} message shown")
 
 
 @step('fields are emptied')
@@ -82,16 +82,6 @@ def empty_fields(context):
     if radios:
         radios[0].click()
     context.browser.find_by_id("create-survey-button").click()
-
-
-@step('I should see error messages other than for sample template')
-def see_error_messages_minus_template(context):
-    test_helper.assertEqual(context.browser.find_by_id("alert", wait_time=5).first.text,
-                            "There are 2 problems with this page", "No error summary shown")
-    test_helper.assertTrue(context.browser.is_text_present("Enter a survey name"),
-                           "No error message shown for name")
-    test_helper.assertTrue(context.browser.is_text_present("Enter a sample definition URL"),
-                           "No error message shown for sample definition URL")
 
 
 @step('a survey with a name longer than 255 characters is attempted to be created')

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -22,9 +22,7 @@ def input_survey_details_and_save_survey(context, survey_name):
     context.browser.find_by_id("sample_definition_url_input").fill(survey_name)
     radios = context.browser.find_by_css("input[type='radio']")
     radios[0].click()
-    button = context.browser.find_by_id("create-survey-button")
-    context.browser.execute_script("arguments[0].scrollIntoView(true);", button._element)
-    button.click()
+    context.browser.find_by_id("create-survey-button").click()
 
 
 @step("I should see the new surveys details")

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -18,10 +18,13 @@ def click_on_create_new_survey_button(context):
 @step('a survey called "{survey_name}" plus unique suffix is created')
 def input_survey_details_and_save_survey(context, survey_name):
     context.survey_name = survey_name + get_random_alpha_numerics(5)
-    context.browser.find_by_id("name_input").fill(context.survey_name)
+    context.browser.find_by_id("name_input", wait_time=5).fill(context.survey_name)
     context.browser.find_by_id("sample_definition_url_input").fill(survey_name)
-    context.browser.find_by_id("sample_validation_rules_input").fill("[]")
-    context.browser.find_by_id("create-survey-button").click()
+    radios = context.browser.find_by_css("input[type='radio']")
+    radios[0].click()
+    button = context.browser.find_by_id("create-survey-button")
+    context.browser.execute_script("arguments[0].scrollIntoView(true);", button._element)
+    button.click()
 
 
 @step("I should see the new surveys details")
@@ -53,3 +56,58 @@ def find_edited_survey_name(context):
                             f"Expected survey name to be {context.edited_survey_name},"
                             f" but found {context.browser.find_by_id("name_value").first.text}")
     test_helper.assertNotEqual(context.survey_name, context.edited_survey_name, "The survey name was not edited")
+
+
+@step('a survey with no filed entered is attempted to be created')
+def create_survey_with_no_name(context):
+    context.browser.find_by_id("create-survey-button").click()
+
+
+@step('I should see error messages')
+def see_error_messages(context):
+    test_helper.assertEqual(context.browser.find_by_id("alert", wait_time=5).first.text,
+                            "There are 3 problems with this page", "No error summary shown")
+    test_helper.assertTrue(context.browser.is_text_present("Enter a survey name"), "No error message shown for name")
+    test_helper.assertTrue(context.browser.is_text_present("Enter a sample definition URL"),
+                           "No error message shown for sample definition URL")
+    test_helper.assertTrue(context.browser.is_text_present("Select a sample template"),
+                           "No error message shown for sample template")
+
+
+@step('fields are emptied')
+def empty_fields(context):
+    context.browser.find_by_id("name_input", wait_time=5).fill("")
+    context.browser.find_by_id("sample_definition_url_input").fill("")
+    radios = context.browser.find_by_css("input[type='radio']:checked")
+    if radios:
+        radios[0].click()
+    context.browser.find_by_id("create-survey-button").click()
+
+
+@step('I should see error messages other than for sample template')
+def see_error_messages_minus_template(context):
+    test_helper.assertEqual(context.browser.find_by_id("alert", wait_time=5).first.text,
+                            "There are 2 problems with this page", "No error summary shown")
+    test_helper.assertTrue(context.browser.is_text_present("Enter a survey name"),
+                           "No error message shown for name")
+    test_helper.assertTrue(context.browser.is_text_present("Enter a sample definition URL"),
+                           "No error message shown for sample definition URL")
+
+
+@step('a survey with a name longer than 255 characters is attempted to be created')
+def create_survey_with_long_name(context):
+    long_name = "This is a very long survey name that is definitely going to be longer than 255 characters. " \
+                "In fact, it is so long that it just keeps going and going and going and going and going and going " \
+                "and going and going and going and going and going and going and going and going and going and " \
+                "going and going and going and going and going and going and going and going and going and going " \
+                "and going and going and going and going and going and going and going!"
+    context.browser.find_by_id("name_input", wait_time=5).fill(long_name)
+    context.browser.find_by_id("sample_definition_url_input").fill("Test URL")
+    radios = context.browser.find_by_css("input[type='radio']")
+    radios[0].click()
+
+
+@step('the name should be truncated to 255 characters')
+def name_truncated_to_255_characters(context):
+    test_helper.assertEqual(len(context.browser.find_by_id("name_input").first.value), 255,
+                            "The survey name is not 255 characters long")


### PR DESCRIPTION
# Motivation and Context
Since we're making good progress on the MVP, we decided it'll be a good idea to get ATs working so we don't miss anything. We have happy paths for the survey page now we need the unhappy path to be tested.


* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date - **Not needed for this PR**

# What has changed
- Updated survey create to use survey template instead of validation rules. 
    - I had an issue where after updating the create survey button wasn't being clicked, when the test was run without the headless tag (HEADLESS set to False), the test worked as expected. I found two solutions, either change the browser window resolution or run a script to scroll the button into view. I've chosen the later, but have no clue why the button wasn't in view but this I believe was the issue.
    - Rather than use an Id to find the radio button (since this value will change depending on what surveys are in frontend), I've just told the driver to find a radio button and click the first one.
- Added 3 new tests: 
    - Create a blank survey
    - Edit a survey and empty fields 
    - Creating a survey with too long of a name (This might not be needed but thought it would be something good to have)
- Swapped the regression tag from the edit a valid survey to create a valid survey 

# How to test?
1. Make up your docker with the latest frontend and api images
2. Run the test and core test
3. check I haven't missed anything that should be tested

# Links
[SDCSRM-1091](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1091)
