### PR TITLE
Regression Test Support Tool Failing Fix

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -70,7 +70,8 @@ def before_scenario(context, scenario):
         service = Service()
         options = Options()
         options.add_argument("--verbose")
-        options.add_argument("--window-size=1920,1080")
+        if "SupportFrontend" in context.tags:
+            options.add_argument("--window-size=1920,1080")
         context.browser = Browser('chrome', headless=Config.HEADLESS, service=service, options=options)
 
 


### PR DESCRIPTION
# Motivation and Context
The Support Tool UI regression tests in the build-deploy-ci-int pipeline kept failing. The most prominent error was:
`selenium.common.exceptions.WebDriverException: Message: tab crashed`
This was due to the ATs being unable to find elements in the Support Tool UI.

* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
After some testing I found this error only ever occurs when there a few surveys etc already in support tool (i.e. the ATs have been ran already and the db hasn't been reset).
My theory behind it failing was as we've added an option to chromedriver to set the window driver in order to fix an issue with the Support Frontend test (https://github.com/ONSdigital/ssdc-rm-acceptance-tests/pull/246). I suspect when selelium tries to find the element it can't as it isn't on the screen.

**This is only a temporary fix**
To fix the issue I've change the window size to only be added when the Supportfrontend tag is given.

I've created a card to look deeper into the problem and come up with a permanent solution (https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1137).

# How to test?
Run the test locally and check they pass
[Run the regression test in a gcp env](https://github.com/ONSdigital/ssdc-rm-acceptance-tests?tab=readme-ov-file#run-tests-against-a-gcp-project). Run the test a few times without clearing anything in the database.

# Links
[Example Error
](https://rm-concourse.gcp.onsdigital.uk/teams/rm-dev/pipelines/build-deploy-ci-integration/jobs/regression-acceptance-tests/builds/1275)
# Screenshots (if appropriate):