### PR TITLE
SDCSRM-1137 Permanent chrome crash fix

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -70,8 +70,7 @@ def before_scenario(context, scenario):
         service = Service()
         options = Options()
         options.add_argument("--verbose")
-        if "SupportFrontend" in context.tags:
-            options.add_argument("--window-size=1920,1080")
+        options.add_argument("--window-size=1920,1080")
         context.browser = Browser('chrome', headless=Config.HEADLESS, service=service, options=options)
 
 

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -29,10 +29,10 @@ spec:
     resources:
       requests:
         cpu: "500m"
-        memory: "512Mi"
+        memory: "800Mi"
       limits:
         cpu: "500m"
-        memory: "512Mi"
+        memory: "800Mi"
     volumeMounts:
     - name: case-cloud-sql-certs
       mountPath: "/home/acceptancetests/postgresql"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

Our regressions tests kept failing, the common error was that a tab had crashed.

# What has changed
I found that the ATs pod kept hitting it's memory limit which caused chrome to crash. So I've increased the Memory limits on the pod.

I've also looked into the issue with buttons not being clicked, since there's a few little things to write about it and still some unknowns I've done a write up on it (https://github.com/ONSdigital/ssdc-rm-documentation/pull/336). TLDR; my suspicions about the button not being in view causing issues was correct, unless we all switch to Chrome for Testing (CfT), the best approach is to go back and set the window size. I've kept it at 1920x1080 since I feel that's what most users will use, and I feel our content should ideally fit in that resolution (let me know if you disagree!).

# How to test?
1. Run the tests locally and check they work
2. Build and tag the ATs and run against a dev GCP project
3. Run the regression tests against a GCP project
All the tests should run

# Links
[Jira - SDCSRM-1137](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1137)
[Documentation PR](https://github.com/ONSdigital/ssdc-rm-documentation/pull/336)

# Screenshots (if appropriate):