### PR TITLE
SDCSRM 1137 rollback fix

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -29,7 +29,7 @@ spec:
     resources:
       requests:
         cpu: "500m"
-        memory: "512mi"
+        memory: "512Mi"
       limits:
         cpu: "500m"
         memory: "512Mi"


### PR DESCRIPTION
# Motivation and Context
The rollback contained a typo in the k8 manifest

* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Fixed the typo

# How to test?
Run the run gke script: `ENV=<env> ./run_gke.sh  `

# Links
[SDCSRM-1137](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1137)

# Screenshots (if appropriate):