### PR TITLE
SDCSRM Support-frontend updated survey edit links

### DIFF
--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -12,7 +12,7 @@ Feature: Test functionality of the Support Frontend
     Given the support frontend is displayed
     And the "Create new survey" button is clicked
     And a survey called "SupportFrontendTest" plus unique suffix is created
-    When the name edit link is clicked
+    When the edit survey link is clicked
     And the name is changed to "EditedSupportFrontendTest"
     Then I should see the edited survey name
 
@@ -30,7 +30,7 @@ Feature: Test functionality of the Support Frontend
     Given the support frontend is displayed
     And the "Create new survey" button is clicked
     And a survey called "SupportFrontendTest" plus unique suffix is created
-    When the name edit link is clicked
+    When the edit survey link is clicked
     And fields are emptied
     Then I should see 2 problems with this page
     And I see a "Enter a survey name" error

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -36,9 +36,9 @@ def find_survey_details(context):
     )
 
 
-@step("the name edit link is clicked")
+@step("the edit survey link is clicked")
 def click_name_edit_link(context):
-    context.browser.find_by_id("name_edit_link", wait_time=5).first.click()
+    context.browser.find_by_id("edit_survey_link", wait_time=5).first.click()
 
 
 @step('the name is changed to "{edited_name}"')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Support Frontend's edit link is being updated to match the new designs. The edit survey details tests have been updated so they are compatible with the updated frontend.

# How to test?
Run the support frontend with the changes
Run the Support_Frontend tests and check they all pass

# Links
[Jira - SDCSRM-1073](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1073)

# Screenshots (if appropriate):