### PR TITLE
SDCSRM-1238 Support-frontend edit collex link

### DIFF
--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -59,7 +59,7 @@ Feature: Test functionality of the Support Frontend
     And a survey called "SupportFrontendCollexTest" plus unique suffix is created
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendCollexTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
-    When the collection exercise name edit link is clicked
+    When the collection exercise edit link is clicked
     And the collection exercise name is changed to "EditedSupportFrontendCollexTest"
     Then I should see the edited collection name
     And the new collection exercise is published to pubsub
@@ -81,7 +81,7 @@ Feature: Test functionality of the Support Frontend
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendCollexTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
     And the new collection exercise is published to pubsub
-    When the collection exercise name edit link is clicked
+    When the collection exercise edit link is clicked
     And the collection exercise name and description is changed to an empty string
     Then I should see 2 problems with this page
 

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -167,9 +167,9 @@ def check_collection_exercise_is_emitted(context, collex_type):
     get_collection_exercise_update_by_name(collection_exercise_name, context.test_start_utc_datetime)
 
 
-@step("the collection exercise name edit link is clicked")
+@step("the collection exercise edit link is clicked")
 def click_collection_exercise_name_edit_link(context):
-    context.browser.find_by_id("collection_exercise_name_edit_link", wait_time=5).first.click()
+    context.browser.find_by_id("edit_collection_exercise_link", wait_time=5).first.click()
 
 
 @step('the collection exercise name is changed to "{edited_name}"')


### PR DESCRIPTION
# Motivation and Context
* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

Support frontend's collection exercise details page has been updated, so the ATs need updating so the tests can still pass

# What has changed
- Changed id for the edit collection exercise link

# How to test?
Build support frontend (https://github.com/ONSdigital/srm-support-frontend/pull/84)
Run the ATs and check they all pass

# Links
[Jira SDCSRM-1238](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1238)

# Screenshots (if appropriate):