### PR TITLE
SDCSRM-1088 Support-frontend actions unhappy path

### DIFF
--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -89,7 +89,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Create a deactivate action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendDeactivateActionRuleTest" plus unique suffix is created
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
     And the new collection exercise is published to pubsub
@@ -101,7 +101,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Create a flush action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendFlushActionRuleTest" plus unique suffix is created
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
     And the new collection exercise is published to pubsub
@@ -113,7 +113,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Edit a flush action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendFlushActionRuleTest" plus unique suffix is created
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
     And the new collection exercise is published to pubsub
@@ -127,7 +127,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Edit a deactivate action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendDeactivateActionRuleTest" plus unique suffix is created
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
     And the new collection exercise is published to pubsub
@@ -141,7 +141,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Create an email action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendEmailActionRuleTest" plus unique suffix is created
     And action rules are authorised for email template "his_survey_test"
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
@@ -154,7 +154,7 @@ Feature: Test functionality of the Support Frontend
   Scenario: Edit an email action rule
     Given the support frontend is displayed
     And the "Create new survey" link is clicked
-    And a survey called "SupportFrontendActionRuleTest" plus unique suffix is created
+    And a survey called "SupportFrontendEmailActionRuleTest" plus unique suffix is created
     And action rules are authorised for email template "his_survey_test"
     And the "Add collection exercise" button is clicked
     And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
@@ -164,3 +164,80 @@ Feature: Test functionality of the Support Frontend
     When the edit action rule link is clicked
     And the action rule trigger time is changed to "12:00"
     Then I should see the edited action rule in the action rules list
+
+  Scenario: Create an invalid flush action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendFlushActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    When the create partial_process action link is clicked
+    And the action rule is saved with no fields entered
+    Then I should see 3 problems with this page
+
+  @regression
+  Scenario: Edit a flush action rule with invalid data
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendFlushActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    And the create partial_process action link is clicked
+    And an action rule of type "partial_process" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    When the edit action rule link is clicked
+    And the cohort number, action rule trigger date and time are changed to an empty string
+    Then I should see 3 problems with this page
+
+  Scenario: Create an invalid deactivate action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendDeactivateActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    When the create deactivate_uac action link is clicked
+    And the action rule is saved with no fields entered
+    Then I should see 3 problems with this page
+
+  @regression
+  Scenario: Edit a deactivate action rule with invalid data
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendDeactivateActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    And the create deactivate_uac action link is clicked
+    And an action rule of type "deactivate_uac" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    When the edit action rule link is clicked
+    And the cohort number, action rule trigger date and time are changed to an empty string
+    Then I should see 3 problems with this page
+
+  Scenario: Create an invalid email action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendEmailActionRuleTest" plus unique suffix is created
+    And action rules are authorised for email template "his_survey_test"
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    When the create email action link is clicked
+    And the action rule is saved with no fields entered
+    Then I should see 4 problems with this page
+
+  @regression
+  Scenario: Edit an email action rule with invalid data
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendEmailActionRuleTest" plus unique suffix is created
+    And action rules are authorised for email template "his_survey_test"
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    And the create email action link is clicked
+    And an action rule of type "email" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    When the edit action rule link is clicked
+    And the cohort number, action rule trigger date and time are changed to an empty string
+    Then I should see 3 problems with this page

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -270,3 +270,17 @@ def find_edited_action_rule_trigger_time(context):
         context.browser.is_text_present(formatted_new_datetime, wait_time=5),
         f"No action rule with trigger date {formatted_new_datetime} in action rules table"
     )
+
+@step('the action rule is saved with no fields entered')
+def create_action_rule_with_no_data(context):
+    context.browser.find_by_id("continue-action-button").click()
+
+@step('the cohort number, action rule trigger date and time are changed to an empty string')
+def change_action_rule_cohort_and_trigger_datetime_to_empty_string(context):
+    context.browser.find_by_id("cohort_number_input").fill("")
+    context.browser.find_by_id("action_date_input-day").fill("")
+    context.browser.find_by_id("action_date_input-month").fill("")
+    context.browser.find_by_id("action_date_input-year").fill("")
+    context.browser.find_by_id("action_time_input-hour").fill("")
+    context.browser.find_by_id("action_time_input-minute").fill("")
+    context.browser.find_by_id("continue-action-button").click()

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -271,9 +271,11 @@ def find_edited_action_rule_trigger_time(context):
         f"No action rule with trigger date {formatted_new_datetime} in action rules table"
     )
 
+
 @step('the action rule is saved with no fields entered')
 def create_action_rule_with_no_data(context):
     context.browser.find_by_id("continue-action-button").click()
+
 
 @step('the cohort number, action rule trigger date and time are changed to an empty string')
 def change_action_rule_cohort_and_trigger_datetime_to_empty_string(context):


### PR DESCRIPTION
# Motivation and Context
Since we're close to MVP, we want Acceptance Tests for some of the self service features. 
This PR is to add tests for Unhappy paths when creating/editing action rules

* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
- Added six new scenarios, an edit and create for each type of action rule.
- I've changed the name of the surveys for the happy edit/create scenarios, just so it's clearer what test the survey was for.

# How to test?
Run the tests locally and check they run
Run just the core tests and check that only the 'core' tests run 
Run against a GCP project to double check the tests don't run

# Links
[Jira - SDCSRM-1088](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1088)

# Screenshots (if appropriate):