### PR TITLE
SDCSRM-1402 Add scenarios for deleting action rules

### DIFF
--- a/CODE_GUIDE.md
+++ b/CODE_GUIDE.md
@@ -85,6 +85,7 @@ logging upon failure in the [audit_trail_helper](/acceptance_tests/utilities/aud
 | edited_collection_exercise__name   | Stores the edited collection exericise name to be used in the scenario              | str      |
 | cohort                             | Stores the cohort number to be used in action scenarios                             | int      |
 | sample_file                        | Stores the sample file name to be used in the scenario                              | str      |
+| action_rule_type                   | Stores the action rule type to be used in the scenario                              | str      |
 
 </div>
 

--- a/acceptance_tests/features/Support_Frontend.feature
+++ b/acceptance_tests/features/Support_Frontend.feature
@@ -242,6 +242,52 @@ Feature: Test functionality of the Support Frontend
     And the cohort number, action rule trigger date and time are changed to an empty string
     Then I should see 3 problems with this page
 
+  Scenario: Delete an email action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendDeleteEmailActionRuleTest" plus unique suffix is created
+    And action rules are authorised for email template "his_survey_test"
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendDeleteActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    And the create email action link is clicked
+    And an action rule of type "email" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    And the edit action rule link is clicked
+    When the delete action rule link is clicked
+    Then I should see the delete confirmation page
+    When the confirm delete action rule link is clicked
+    Then I should not see any actions in the action rules summary
+
+  Scenario: Delete a flush action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendDeleteFlushActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendDeleteActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    When the create partial_process action link is clicked
+    And an action rule of type "partial_process" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    And the edit action rule link is clicked
+    When the delete action rule link is clicked
+    Then I should see the delete confirmation page
+    When the confirm delete action rule link is clicked
+    Then I should not see any actions in the action rules summary
+
+  Scenario: Delete a deactivate action rule
+    Given the support frontend is displayed
+    And the "Create new survey" link is clicked
+    And a survey called "SupportFrontendDeleteDeactivateActionRuleTest" plus unique suffix is created
+    And the "Add collection exercise" button is clicked
+    And a collection exercise called "SupportFrontendDeleteActionRuleTest" plus unique suffix, with a start date of "2050-01-01" and an end date of "2050-12-31" is created
+    And the new collection exercise is published to pubsub
+    When the create deactivate_uac action link is clicked
+    And an action rule of type "deactivate_uac" for cohort "1", with a trigger date of "2050-12-30" and a trigger time of "10:00" is created
+    And the edit action rule link is clicked
+    When the delete action rule link is clicked
+    Then I should see the delete confirmation page
+    When the confirm delete action rule link is clicked
+    Then I should not see any actions in the action rules summary
+
   # TODO: This will need to be updated to work in cloud environments where the sample file will need to be put in a GCP bucket
   @regression
   Scenario: Upload a sample file

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -220,6 +220,7 @@ def create_action_rule(context, action_rule_type, cohort, trigger_date, trigger_
     context.cohort = cohort
     context.action_trigger_date = dict(zip(["year", "month", "day"], trigger_date.split("-")))
     context.action_trigger_time = dict(zip(["hour", "minute"], trigger_time.split(":")))
+    context.action_rule_type = action_rule_type
     context.browser.find_by_id("cohort_number_input").fill(cohort)
     context.browser.find_by_id("action_date_input-day").fill(context.action_trigger_date["day"])
     context.browser.find_by_id("action_date_input-month").fill(context.action_trigger_date["month"])
@@ -348,7 +349,14 @@ def confirm_delete_action(context):
 
 @step('I should not see any actions in the action rules summary')
 def check_deleted_action_rule(context):
-    test_helper.assertFalse(
-        context.browser.is_text_present("1 action", wait_time=5),
-        "No actions should be present in the action rules summary after deletion"
+    match context.action_rule_type:
+        case 'deactivate_uac':
+            no_actions_present_text = "No deactivation actions have been set up for this collection exercise"
+        case 'partial_process':
+            no_actions_present_text = "No actions have been set up to process partial responses for this collection exercise."
+        case _:
+            no_actions_present_text = f"No {context.action_rule_type.replace("_", " ")} actions have been set up for this collection exercise."
+
+    test_helper.assertTrue(
+        context.browser.is_text_present(no_actions_present_text, wait_time=5),
     )

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -343,7 +343,7 @@ def delete_confirmation_page(context):
 
 @step('the confirm delete action rule link is clicked')
 def confirm_delete_action(context):
-    context.browser.find_by_id("confirm-delete_action_button").click()
+    context.browser.find_by_id("confirm_delete_action_button").click()
 
 
 @step('I should not see any actions in the action rules summary')

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -327,3 +327,28 @@ def find_sample_file_details(context):
         originating_user_email=Config.FRONTEND_USER_EMAIL
     )
     test_helper.assertEqual(len(context.emitted_cases), context.sample_count)
+
+
+@step('the delete action rule link is clicked')
+def delete_action_rule_link(context):
+    context.browser.find_by_id("delete_action_rule_link").click()
+
+
+@step('I should see the delete confirmation page')
+def delete_confirmation_page(context):
+    test_helper.assertTrue(
+        context.browser.is_text_present("Are you sure you want to delete"), "No delete confirmation present"
+    )
+
+
+@step('the confirm delete action rule link is clicked')
+def confirm_delete_action(context):
+    context.browser.find_by_id("confirm-delete_action_button").click()
+
+
+@step('I should not see any actions in the action rules summary')
+def check_deleted_action_rule(context):
+    test_helper.assertFalse(
+        context.browser.is_text_present("1 action", wait_time=5),
+        "No actions should be present in the action rules summary after deletion"
+    )

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -353,9 +353,11 @@ def check_deleted_action_rule(context):
         case 'deactivate_uac':
             no_actions_present_text = "No deactivation actions have been set up for this collection exercise"
         case 'partial_process':
-            no_actions_present_text = "No actions have been set up to process partial responses for this collection exercise."
+            no_actions_present_text = \
+                "No actions have been set up to process partial responses for this collection exercise."
         case _:
-            no_actions_present_text = f"No {context.action_rule_type.replace("_", " ")} actions have been set up for this collection exercise."
+            no_actions_present_text = (f"No {context.action_rule_type.replace("_", " ")} actions "
+                                       f"have been set up for this collection exercise.")
 
     test_helper.assertTrue(
         context.browser.is_text_present(no_actions_present_text, wait_time=5),


### PR DESCRIPTION
# Motivation and Context
We need ATs for the new delete action rule feature
* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Added 3 scenarios to test deletion of each type of action rule

# How to test?
Run along side frontend PR (https://github.com/ONSdigital/srm-support-frontend/pull/95)

# Links
[Jira - SDCSRM-1402](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1402)

# Screenshots (if appropriate):