### PR TITLE
SDCSRM 1223 Support Frontend Tests GCP

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -16,6 +16,7 @@ from acceptance_tests.utilities.audit_trail_helper import log_out_user_context_v
 from acceptance_tests.utilities.eq_stub_helper import reset_eq_stub
 from acceptance_tests.utilities.exception_manager_helper import get_bad_messages, \
     quarantine_bad_messages_check_and_reset
+from acceptance_tests.utilities.iap_requests import get_support_frontend_headers
 from acceptance_tests.utilities.notify_helper import reset_notify_stub
 from acceptance_tests.utilities.parameter_parsers import parse_array_to_list, parse_json_object
 from acceptance_tests.utilities.pubsub_helper import purge_outbound_topics_with_retry, purge_outbound_topics
@@ -73,6 +74,21 @@ def before_scenario(context, scenario):
         if "SupportFrontend" in context.tags:
             options.add_argument("--window-size=1920,1080")
         context.browser = Browser('chrome', headless=Config.HEADLESS, service=service, options=options)
+
+    if "SupportFrontend" in context.tags:
+        if Config.SUPPORT_FRONTEND_IAP_CLIENT_ID:
+
+            # TODO: Needs to be removed when sample files ATs work in GCP
+            if scenario.name == "Upload a sample file":
+                scenario.skip("Skipping - Sample file Scenarios aren't supported in GCP yet")
+
+            headers = get_support_frontend_headers()
+            context.browser.driver.execute_cdp_cmd(
+                "Network.enable", {}
+            )
+            context.browser.driver.execute_cdp_cmd(
+                "Network.setExtraHTTPHeaders", headers
+            )
 
 
 def after_all(_context):

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -71,8 +71,6 @@ def before_scenario(context, scenario):
         service = Service()
         options = Options()
         options.add_argument("--verbose")
-        if "SupportFrontend" in context.tags:
-            options.add_argument("--window-size=1920,1080")
         context.browser = Browser('chrome', headless=Config.HEADLESS, service=service, options=options)
 
     if "SupportFrontend" in context.tags:

--- a/acceptance_tests/features/steps/support_frontend.py
+++ b/acceptance_tests/features/steps/support_frontend.py
@@ -71,7 +71,7 @@ def find_edited_survey_name(context):
 
 @step('a survey with no filed entered is attempted to be created')
 def create_survey_with_no_name(context):
-    context.browser.find_by_id("create-survey-button").click()
+    context.browser.find_by_id("create-survey-button", wait_time=5).click()
 
 
 @step('I should see {num_errors} problems with this page')
@@ -116,7 +116,7 @@ def name_truncated_to_255_characters(context):
 
 @step('the "Add collection exercise" button is clicked')
 def add_collection_exercise_button(context):
-    context.browser.find_by_id("add-new-collection-exercise-link").click()
+    context.browser.find_by_id("add-new-collection-exercise-link", wait_time=5).click()
 
 
 @step(
@@ -127,7 +127,7 @@ def create_collection_exercise(context, collection_exercise_name, start_date, en
     context.collection_exercise_name = collection_exercise_name + get_random_alpha_numerics(5)
     context.collection_exercise_start_date = dict(zip(["year", "month", "day"], start_date.split("-")))
     context.collection_exercise_end_date = dict(zip(["year", "month", "day"], end_date.split("-")))
-    context.browser.find_by_id("collection_exercise_name_input").fill(context.collection_exercise_name)
+    context.browser.find_by_id("collection_exercise_name_input", wait_time=5).fill(context.collection_exercise_name)
     context.browser.find_by_id("description_input").fill(context.collection_exercise_name)
     context.browser.find_by_id("start_date_input-day").fill(context.collection_exercise_start_date["day"])
     context.browser.find_by_id("start_date_input-month").fill(context.collection_exercise_start_date["month"])
@@ -179,7 +179,8 @@ def click_collection_exercise_name_edit_link(context):
 @step('the collection exercise name is changed to "{edited_name}"')
 def change_collection_exercise_name(context, edited_name):
     context.edited_collection_exercise_name = edited_name + get_random_alpha_numerics(5)
-    context.browser.find_by_id("collection_exercise_name_input").fill(context.edited_collection_exercise_name)
+    (context.browser.find_by_id("collection_exercise_name_input", wait_time=5)
+     .fill(context.edited_collection_exercise_name))
     context.browser.find_by_id("create-collection-exercise-button").click()
 
 
@@ -220,7 +221,7 @@ def create_action_rule(context, action_rule_type, cohort, trigger_date, trigger_
     context.cohort = cohort
     context.action_trigger_date = dict(zip(["year", "month", "day"], trigger_date.split("-")))
     context.action_trigger_time = dict(zip(["hour", "minute"], trigger_time.split(":")))
-    context.browser.find_by_id("cohort_number_input").fill(cohort)
+    context.browser.find_by_id("cohort_number_input", wait_time=5).fill(cohort)
     context.browser.find_by_id("action_date_input-day").fill(context.action_trigger_date["day"])
     context.browser.find_by_id("action_date_input-month").fill(context.action_trigger_date["month"])
     context.browser.find_by_id("action_date_input-year").fill(context.action_trigger_date["year"])
@@ -258,7 +259,7 @@ def click_edit_action_link(context):
 @step('the action rule trigger time is changed to "{new_trigger_time}"')
 def change_action_rule_trigger_time(context, new_trigger_time):
     context.new_action_trigger_time = dict(zip(["hour", "minute"], new_trigger_time.split(":")))
-    context.browser.find_by_id("action_time_input-hour").fill(context.new_action_trigger_time["hour"])
+    context.browser.find_by_id("action_time_input-hour", wait_time=5).fill(context.new_action_trigger_time["hour"])
     context.browser.find_by_id("action_time_input-minute").fill(context.new_action_trigger_time["minute"])
     context.browser.find_by_id("continue-action-button").click()
 
@@ -283,7 +284,7 @@ def create_action_rule_with_no_data(context):
 
 @step('the cohort number, action rule trigger date and time are changed to an empty string')
 def change_action_rule_cohort_and_trigger_datetime_to_empty_string(context):
-    context.browser.find_by_id("cohort_number_input").fill("")
+    context.browser.find_by_id("cohort_number_input", wait_time=5).fill("")
     context.browser.find_by_id("action_date_input-day").fill("")
     context.browser.find_by_id("action_date_input-month").fill("")
     context.browser.find_by_id("action_date_input-year").fill("")
@@ -294,7 +295,7 @@ def change_action_rule_cohort_and_trigger_datetime_to_empty_string(context):
 
 @step('the upload sample file link is clicked')
 def click_upload_sample_file_link(context):
-    context.browser.find_by_id("upload_sample_file_link").click()
+    context.browser.find_by_id("upload_sample_file_link", wait_time=5).click()
 
 
 @step('the "{sample_file}" sample file is uploaded')
@@ -302,7 +303,7 @@ def upload_sample_file(context, sample_file):
     context.sample_file = sample_file
     sample_file_path = Config.SAMPLE_FILES_PATH.joinpath(context.sample_file)
     context.sample_count = sum(1 for _ in open(sample_file_path)) - 1
-    context.browser.find_by_id(f"sample-file-{context.sample_file}").click()
+    context.browser.find_by_id(f"sample-file-{context.sample_file}", wait_time=5).click()
     context.browser.find_by_id("upload-sample-file-button").click()
 
 

--- a/acceptance_tests/utilities/iap_requests.py
+++ b/acceptance_tests/utilities/iap_requests.py
@@ -22,6 +22,26 @@ def make_request(method: str = "GET", url: str = None,
     return requests.request(method, url, **kwargs)
 
 
+def get_support_frontend_headers(iap_client_id: str = Config.SUPPORT_FRONTEND_IAP_CLIENT_ID) -> dict:
+    """Get headers required for IAP authentication with SRM Support.
+
+    Args:
+        iap_client_id: (Optional) The IAP Client ID for srm support to use for authentication.
+        If not configured, it will fall back on a regular,
+        unauthenticated request. Defaults to the configured Support Frontend Client if present.
+
+    Returns:
+        Dictionary of headers required for IAP authentication with SRM Support.
+    """
+    if not iap_client_id:
+        return {"headers": {}}
+
+    token = id_token.fetch_id_token(Request(), iap_client_id)
+    return {
+        "headers": {"Authorization": f"Bearer {token}"}
+    }
+
+
 def _make_iap_request(method: str = 'GET', url: str = None, iap_client_id: str = None, **kwargs) -> requests.Response:
     """Makes a request to an application protected by Identity-Aware Proxy.
     Args:

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -120,6 +120,13 @@ spec:
           key: client_id
     - name: API_USER_EMAIL
       value: "acceptance-tests@ssdc-rm-$ENV.iam.gserviceaccount.com"
+    - name: SUPPORT_FRONTEND_URL
+      value: "https://srm-support-$ENV.rm.gcp.onsdigital.uk"
+    - name: SUPPORT_FRONTEND_IAP_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: support-frontend-iap
+          key: client_id
   volumes:
   - name: export-file-destinations
     secret:

--- a/config.py
+++ b/config.py
@@ -108,3 +108,5 @@ class Config:
     SUPPORT_FRONTEND_URL = os.getenv('SUPPORT_FRONTEND_URL', 'http://localhost:9096/')
     # Support Frontend doesn't currently set a user email in pub/sub messages
     FRONTEND_USER_EMAIL = os.getenv('FRONTEND_USER_EMAIL', None)
+
+    SUPPORT_FRONTEND_IAP_CLIENT_ID = os.getenv('SUPPORT_FRONTEND_IAP_CLIENT_ID')


### PR DESCRIPTION
# Motivation and Context
We want to be able to run Support Frontend scenarios in GCP environments 

* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
- Added IAP auth headers to support frontend requests when running in cloud env
- Added some wait times (currently support frontend is a bit sluggish in dev sandbox envs)
- Skipped the Sample Load Scenario as this requires extra work to get working in gcp (We have a card to look into this already)

When running the tests it kept crashing due to memory limits, this is partly due to window size being set. I've noticed now if you remove the window option, the ATs still pass on the new and old macs. This also stops the chromedriver tab from cashing.

Sometimes the memory limit is hit so the pod exists, I'm leaving that fix out of this card as we already have a card looking into it

# How to test?
1. Apply Terraform changes (https://github.com/ONSdigital/ssdc-rm-terraform/pull/708)
2. Remove `~@SupportFrontend` from L54 of `run_gke.sh` to allow the Support Frontend tests to run (This has been left in to not break CI pipeline)
3. Build and run the ATs against a dev project
4. Run the ATs locally to check they still work

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1223

# Screenshots (if appropriate):