### PR TITLE
SCDSRM-1223 [Fix] optional support frontend secret

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -127,6 +127,7 @@ spec:
         secretKeyRef:
           name: support-frontend-iap
           key: client_id
+          optional: true
   volumes:
   - name: export-file-destinations
     secret:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
Added optional flag for support frontend iap env var

# How to test?
Apply the manifest to a sandbox project without the `support-frontend-iap` secret and it should run

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1223

# Screenshots (if appropriate):