### PR TITLE
SDCSRM-1551 temp-regression-test-fix

### DIFF
--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -245,8 +245,9 @@ def check_action_rule_triggered_for_email(context, email_column):
 @step('I can see the action rule has been created in "{expected_timezone}"')
 def check_action_rule_triggered_for_email_in_future(context, expected_timezone):
     action_rule_date_time_str = context.browser.find_by_id('actionRuleDateTime', wait_time=30).text
-
     if expected_timezone == "GMT":
+        # TODO: Find a permanent fix for +00:00 being added to the end of the date time string in GMT timezone.
+        action_rule_date_time_str = action_rule_date_time_str.rstrip("+00:00")
         action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z")
         test_helper.assertIsNone(action_rule_date_time.utcoffset())  # Time is in UTC, so we assert there's no offset
     else:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

The regression tests have broken, this is a temp fix so the tests can still run overnight

# What has changed
For some reason the action rule date time is having `+00:00` added on in GCP envs which causes the datetime parsing to error out.
I will raise a card to properly look into the issue as it seems to persist on different AT and Support Tool image versions. 

-Stripped `+00:00` from GMT timezone 

# How to test?
1. Run `make build`, tag the image and push it to an artifact registry
2. Either run all the regression tests against a sandbox project or change line 54 in `run_gke.sh` to only run the broken test: `behave acceptance_tests/features -n 'Support tool displays action rules with correct timezone'` 

# Links
[SDCSRM-1551](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1551)
[SDCSRM-1553 - Card to look properly into the issue](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1553)

# Screenshots (if appropriate):