### PR TITLE
SDCSRM-1224 srm-support in ci int

### DIFF
--- a/run_gke.sh
+++ b/run_gke.sh
@@ -51,6 +51,6 @@ kubectl exec -it acceptance-tests -- /bin/bash -c \
   "sleep 2;  python -m poll_endpoint --url https://support-tool-$ENV.rm.gcp.onsdigital.uk/actuator/health --max_retries 10"
 
 
-kubectl exec -it acceptance-tests -- /bin/bash -c "sleep 2; behave acceptance_tests/features $BEHAVE_TAGS --tags=~@SupportFrontend --logging-level WARN"
+kubectl exec -it acceptance-tests -- /bin/bash -c "sleep 2; behave acceptance_tests/features $BEHAVE_TAGS --logging-level WARN"
 
 kubectl delete pod acceptance-tests || true

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -57,7 +57,7 @@ run:
       # Exec into the pod to run the tests while tailing their logs
       # The sleep is to give kubectl time to attach properly, otherwise the first few log lines are lost
       kubectl exec -it acceptance-tests -- /bin/bash -c \
-      "sleep 2; behave acceptance_tests/features --logging-level WARN ${BEHAVE_TAGS} --tags=~@SupportFrontend "
+      "sleep 2; behave acceptance_tests/features --logging-level WARN ${BEHAVE_TAGS}"
   
       # Clean up the pod once we're finished
       kubectl delete pod acceptance-tests || true


### PR DESCRIPTION
# Motivation and Context
We want to deploy self service to ci and int
* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
- Removed exclude tag for srm support tests in gcp
Something to note is that the sample file ATs have been disabled in another PR and there is a card to look into getting that test updated for GCP envs

# How to test?
Run the ATs against a sandbox project

# Links
[Jira - SDCSRM-1224](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1224)

# Screenshots (if appropriate):