### PR TITLE
SDCSRM-1553 Regression test GMT failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get -y update && apt-get install -y curl git wget gnupg jq unzip &&  \
     wget -O /tmp/chromedriver.zip `jq -r '.channels.Stable.downloads.chromedriver|.[]|select(.platform=="linux64").url' /tmp/chrome-versions.json` && \
     # Setup chrome
     unzip /tmp/chrome.zip -d /opt/chrome && \
-    ln -s /opt/chrome/chrome-linux64/chrome /usr/local/bin/google-chrome && \
+    ln -s /opt/chrome/chrome-linux64/chrome /usr/local/bin/chrome && \
     # Install dependencies for chrome
     while read pkg; do \
       apt-get satisfy -y --no-install-recommends "${pkg}"; \
@@ -23,6 +23,9 @@ RUN pip3 install pipenv
 # set display port to avoid crash
 ENV DISPLAY=:99
 WORKDIR /home/acceptancetests
+
+# Force selenium manager to avoid downloading chrome
+ENV SE_AVOID_BROWSER_DOWNLOAD=true
 
 COPY Pipfile* /home/acceptancetests/
 RUN pipenv install --system --deploy --dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN pip3 install pipenv
 ENV DISPLAY=:99
 WORKDIR /home/acceptancetests
 
-# Force selenium manager to avoid downloading chrome
-ENV SE_AVOID_BROWSER_DOWNLOAD=true
-
 COPY Pipfile* /home/acceptancetests/
 RUN pipenv install --system --deploy --dev
 USER acceptancetests

--- a/acceptance_tests/features/steps/supporttool_ui.py
+++ b/acceptance_tests/features/steps/supporttool_ui.py
@@ -1,4 +1,5 @@
 import json
+import re
 import uuid
 from datetime import datetime
 from typing import List
@@ -246,10 +247,12 @@ def check_action_rule_triggered_for_email(context, email_column):
 def check_action_rule_triggered_for_email_in_future(context, expected_timezone):
     action_rule_date_time_str = context.browser.find_by_id('actionRuleDateTime', wait_time=30).text
     if expected_timezone == "GMT":
-        # TODO: Find a permanent fix for +00:00 being added to the end of the date time string in GMT timezone.
-        action_rule_date_time_str = action_rule_date_time_str.rstrip("+00:00")
-        action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z")
-        test_helper.assertIsNone(action_rule_date_time.utcoffset())  # Time is in UTC, so we assert there's no offset
+        # Since Chrome 148 +00:00 is added to the datetime
+        # Adding +00:00 if it doesn't already exist to support older browsers
+        if not re.search(r'\+\d{2}:\d{2}$', action_rule_date_time_str):
+            action_rule_date_time_str += '+00:00'
+        action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z%z")
+        test_helper.assertEqual(action_rule_date_time.utcoffset().seconds, 0)
     else:
         action_rule_date_time = datetime.strptime(action_rule_date_time_str, "%d/%m/%Y, %H:%M:%S %Z%z")
         test_helper.assertEqual(action_rule_date_time.utcoffset().seconds, 3600)

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -41,8 +41,6 @@ spec:
       mountPath: "/home/acceptancetests/destination_config"
       readOnly: true
     env:
-    - name: TZ
-      value: "Europe/London"
     - name: DB_USERNAME
       valueFrom:
         secretKeyRef:
@@ -130,6 +128,10 @@ spec:
           name: support-frontend-iap
           key: client_id
           optional: true
+    - name: SE_AVOID_BROWSER_DOWNLOAD
+      value: "True"
+    - name: TZ
+      value: "Europe/London"
   volumes:
   - name: export-file-destinations
     secret:

--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -41,6 +41,8 @@ spec:
       mountPath: "/home/acceptancetests/destination_config"
       readOnly: true
     env:
+    - name: TZ
+      value: "Europe/London"
     - name: DB_USERNAME
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
# Motivation and Context
The regression tests started to fail due to '+00:00' randomly being added to GMT timezones by selenium webdrvier

* [x] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
There's two bugs that caused the issue:
1. It seems that since chrome version 148 time is rendered differently in the browser. Due to the specific function we use in JS to show the local time, chrome has started to add +00:00 to it as it localises it. 
I don't think there's anything we can do so I've changed the tests to handle this by default and added support for older browsers. I've also added a TZ to the AT pd - this is just to enforce that is uses the correct local timezone (this wont change anything)

2. Selenium Manager can't seem to find chrome binary.
Selenium couldn't detect chrome so it always installed it itself, which explains why the failure happened randomly and persisted  across older images.
I've renamed the symbolic link to just chrome which selenium can find. As sometimes it will still try and update to the latest chrome, I've added an env var to tell Selenium to not download chrome

# How to test?
1. Run the test locally and against a sandbox project to check it all passes
(You can run just the errored test by running `pipenv run behave acceptance_tests/features/SupportTool_UI.feature -n 'Support tool displays action rules with correct timezone'`)

2. If you run it in gcp, exec into the pod and check chrome hasn't been installed by Selenium:
`kubectl exec -it acceptance-tests -- /bin/bash -c "ls ~/.cache/selenium"` (you should just see a metadata file) 


# Links
[Jira SDCSRM-1553](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1553)

# Screenshots (if appropriate):