### PR TITLE
SDCSRM-1622 Increase memory limits

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -29,10 +29,10 @@ spec:
     resources:
       requests:
         cpu: "500m"
-        memory: "512Mi"
+        memory: "750Mi"
       limits:
         cpu: "500m"
-        memory: "512Mi"
+        memory: "750Mi"
     volumeMounts:
     - name: case-cloud-sql-certs
       mountPath: "/home/acceptancetests/postgresql"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
* [ ] [Context Index](github.com/ONSdigital/ssdc-rm-acceptance-tests/CODE_GUIDE.md#context-index) has been kept up to date

# What has changed
The regression tests in concourse keep failing due to python terminating with error code 137.
It seems that when looking at the resources it hits memory limits in ssdc-rm-ci. I think there might be a bigger underlying issue but for now this is just a quick fix to prevent the tests from failing overnight

# How to test?
Run the test against a sandbox project and check the memory limits are 750mb

# Links
[SDCSRM-1622](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1622)

# Screenshots (if appropriate):

[SDCSRM-1622]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ